### PR TITLE
Add scheduled encrypted vault backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Code deployment is handled by GitHub Actions (`.github/workflows/deploy.yml`), n
 ## UI Features
 * Security audit for reused passwords and HaveIBeenPwned breach checks, with paged results for large vaults.
 * Import/export tooling for JSON backups and CSV transfer workflows.
+* Scheduled encrypted vault backups: the API exports encrypted Cosmos password documents to a zipped blob archive without decrypting stored passwords.
 * Recycle bin for soft-deleted accounts.
 * Per-user settings for generator defaults, list behavior, clipboard auto-clear, idle lock, and password-age reminders.
 * Dark/light vault theme toggle.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -27,16 +27,19 @@ The main resource group hosts the running vault:
 | Component | Resource(s) | Notes |
 |-----------|-------------|-------|
 | **Cosmos DB** | `azurerm_cosmosdb_account` + SQL database `AccountPasswords` | Session consistency, system-assigned identity, free tier enabled by default for new accounts unless `COSMOSDB_FREE_TIER=false` is set. |
-| → Containers | `Passwords`, `VaultKeys` | Both partitioned on `/PartitionKey`. `VaultKeys` (OFF-4 §5B) holds the opaque vault-key record and is isolated so it never appears in the passwords list. |
+| → Containers | `Passwords`, `VaultKeys` | Both partitioned on `/PartitionKey`. `VaultKeys` (OFF-4 §5B) holds the opaque vault-key record and the server-side encrypted backup schedule/status so those records never appear in the passwords list. |
 | **Key Vault** | `azurerm_key_vault` + secrets | RBAC-authorized. Secrets: `aes-encryption-key`, `aes-encryption-iv`, `cosmosdb-connection-string`, `appinsights-connection-string`, `appinsights-key`. |
 | **Function App** | `azurerm_function_app_flex_consumption` on a Linux Flex Consumption `azurerm_service_plan` (`FC1`) | .NET 10 isolated worker; code is deployed by GitHub Actions using the Azure Functions deploy action. HTTP triggers are `Anonymous` (guarded by Entra middleware, AC-2). |
 | **Identity & RBAC** | `azurerm_user_assigned_identity.functions_identity` + role assignments | Function reads Key Vault (`Key Vault Secrets User`) and storage (`Blob Owner`/`Contributor`) via managed identity. A deployer KV access assignment supports `task` runs. |
-| **Storage** | `azurerm_storage_account` + `app` container | Flex Consumption deployment storage for function code and runtime artifacts. |
+| **Storage** | `azurerm_storage_account` + `app`, `vault-backups` containers | Flex Consumption deployment storage for function code/runtime artifacts plus private zipped encrypted vault backup archives. |
 | **Observability** | `azurerm_log_analytics_workspace` + `azurerm_application_insights` | Connection string/key stored in Key Vault and referenced by the Function App. |
 | **UI hosting** | `azurerm_static_web_app` (+ optional `..._custom_domain`) | Vue 3 SPA deployed by GitHub Actions via the SWA CLI. Custom domain gated by `add_custom_domain`. |
 
+## Scheduled encrypted backups
+The .NET API Function App owns scheduled vault backups. A timer trigger (`BACKUP_TIMER_SCHEDULE`, default every 15 minutes) checks the schedule saved from the Settings page, exports the encrypted password documents as-is, writes `passwords.json` and `manifest.json` into a zip archive, and uploads it to the private `vault-backups` storage container. The backup process does not decrypt password values.
+
 ## Maintenance resource group _(optional)_
-Created when `deploy_maintenance_infrastructure = true` (`infrastructure/maintenance/`): its own resource group, storage account + `app` container, Linux service plan, **Python Function App** (keep-alive + backup), a user-assigned identity and the matching storage role assignments.
+Created when `deploy_maintenance_infrastructure = true` (`infrastructure/maintenance/`): its own resource group, storage account + `app` container, Linux service plan, **Python Function App** (keep-alive + legacy backup), a user-assigned identity and the matching storage role assignments. The API-hosted scheduled encrypted backup feature is intended to replace this optional project after rollout.
 
 ## CI/CD & supply chain
 * **Workflows** (`.github/workflows/`): `ci.yml` (build/test/lint + `terraform fmt`/`validate` on every PR), `infra.yml` (`task plan` on PR, `task apply` on `main` behind the `production` Environment), `deploy.yml` (`task deploy-*`, OIDC, Environment-gated).

--- a/infrastructure/functions.tf
+++ b/infrastructure/functions.tf
@@ -61,6 +61,9 @@ resource "azurerm_function_app_flex_consumption" "this" {
     AAD_TENANT_ID                         = var.aad_tenant_id
     AAD_AUDIENCE                          = var.aad_audience
     AAD_ALLOWED_OIDS                      = var.aad_allowed_oids
+    BACKUP_STORAGE_ACCOUNT_NAME           = azurerm_storage_account.this.name
+    BACKUP_STORAGE_CONTAINER_NAME         = azurerm_storage_container.vault_backups.name
+    BACKUP_TIMER_SCHEDULE                 = "0 */15 * * * *"
     APPLICATIONINSIGHTS_CONNECTION_STRING = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.appinsights_connection_string.id})"
     APPINSIGHTS_INSTRUMENTATIONKEY        = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.appinsights_key.id})"
   }

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -12,3 +12,9 @@ resource "azurerm_storage_container" "apps_container" {
   storage_account_id    = azurerm_storage_account.this.id
   container_access_type = "private"
 }
+
+resource "azurerm_storage_container" "vault_backups" {
+  name                  = "vault-backups"
+  storage_account_id    = azurerm_storage_account.this.id
+  container_access_type = "private"
+}

--- a/src/passwordapp.api.tests/VaultBackupArchiveTests.cs
+++ b/src/passwordapp.api.tests/VaultBackupArchiveTests.cs
@@ -1,0 +1,55 @@
+using System.IO.Compression;
+using Newtonsoft.Json;
+using PasswordService.Common;
+using PasswordService.Models;
+
+namespace PasswordService.Tests;
+
+public class VaultBackupArchiveTests
+{
+    [Fact]
+    public void Create_ZipsEncryptedPasswordDocumentsWithoutDecrypting()
+    {
+        var accounts = new[]
+        {
+            new AccountPassword
+            {
+                id = "acct-1",
+                PartitionKey = "Passwords",
+                SiteName = "example.com",
+                AccountName = "alice",
+                CurrentPassword = "v2.gcm.iv.cipher",
+                OldPasswords = new List<PasswordHistory>
+                {
+                    new()
+                    {
+                        Password = new PasswordEntity("v2.gcm.oldiv.oldcipher"),
+                        CreatedDate = DateTime.Parse("2026-01-01T00:00:00Z"),
+                    },
+                },
+                Notes = "metadata stays",
+            },
+        };
+
+        var result = VaultBackupArchive.Create(accounts, DateTimeOffset.Parse("2026-06-25T20:00:00Z"));
+
+        Assert.Equal("vault-backups/vault-backup-20260625-200000.zip", result.BlobName);
+        Assert.Equal(1, result.DocumentCount);
+
+        using var zip = new ZipArchive(new MemoryStream(result.ZipBytes), ZipArchiveMode.Read);
+        var passwordsEntry = zip.GetEntry("passwords.json");
+        Assert.NotNull(passwordsEntry);
+        using var reader = new StreamReader(passwordsEntry!.Open());
+        var json = reader.ReadToEnd();
+
+        Assert.Contains("v2.gcm.iv.cipher", json);
+        Assert.Contains("\"Iv\": \"oldiv\"", json);
+        Assert.Contains("\"EncryptedPassword\": \"oldcipher\"", json);
+        Assert.Contains("metadata stays", json);
+        Assert.DoesNotContain("alice-password", json);
+
+        var restored = JsonConvert.DeserializeObject<List<AccountPassword>>(json);
+        Assert.Single(restored!);
+        Assert.Equal("v2.gcm.iv.cipher", restored![0].CurrentPassword);
+    }
+}

--- a/src/passwordapp.api.tests/VaultBackupSchedulerTests.cs
+++ b/src/passwordapp.api.tests/VaultBackupSchedulerTests.cs
@@ -1,0 +1,67 @@
+using PasswordService.Common;
+using PasswordService.Models;
+
+namespace PasswordService.Tests;
+
+public class VaultBackupSchedulerTests
+{
+    [Fact]
+    public void DisabledSettingsDoNotRun()
+    {
+        var settings = new BackupSettingsRecord
+        {
+            Enabled = false,
+            Frequency = "daily",
+            TimeOfDay = "02:00",
+            TimeZoneId = "UTC",
+        };
+
+        Assert.False(VaultBackupScheduler.ShouldRun(settings, DateTimeOffset.Parse("2026-06-25T03:00:00Z")));
+    }
+
+    [Fact]
+    public void DailyBackupRunsWhenDueAndNotAlreadyRun()
+    {
+        var settings = new BackupSettingsRecord
+        {
+            Enabled = true,
+            Frequency = "daily",
+            TimeOfDay = "02:00",
+            TimeZoneId = "UTC",
+            LastBackupAt = new DateTime(2026, 6, 24, 2, 30, 0, DateTimeKind.Utc),
+        };
+
+        Assert.True(VaultBackupScheduler.ShouldRun(settings, DateTimeOffset.Parse("2026-06-25T02:01:00Z")));
+    }
+
+    [Fact]
+    public void DailyBackupDoesNotRunTwiceForSameDueTime()
+    {
+        var settings = new BackupSettingsRecord
+        {
+            Enabled = true,
+            Frequency = "daily",
+            TimeOfDay = "02:00",
+            TimeZoneId = "UTC",
+            LastBackupAt = new DateTime(2026, 6, 25, 2, 1, 0, DateTimeKind.Utc),
+        };
+
+        Assert.False(VaultBackupScheduler.ShouldRun(settings, DateTimeOffset.Parse("2026-06-25T03:00:00Z")));
+    }
+
+    [Fact]
+    public void WeeklyBackupUsesConfiguredDay()
+    {
+        var settings = new BackupSettingsRecord
+        {
+            Enabled = true,
+            Frequency = "weekly",
+            TimeOfDay = "02:00",
+            TimeZoneId = "UTC",
+            DayOfWeek = DayOfWeek.Thursday,
+            LastBackupAt = new DateTime(2026, 6, 18, 2, 1, 0, DateTimeKind.Utc),
+        };
+
+        Assert.True(VaultBackupScheduler.ShouldRun(settings, DateTimeOffset.Parse("2026-06-25T02:01:00Z")));
+    }
+}

--- a/src/passwordapp.api.tests/passwordapp.api.tests.csproj
+++ b/src/passwordapp.api.tests/passwordapp.api.tests.csproj
@@ -31,12 +31,16 @@
     <Compile Include="..\passwordapp.api\Common\VaultMigration.cs" Link="Common\VaultMigration.cs" />
     <Compile Include="..\passwordapp.api\Common\DocumentMigrator.cs" Link="Common\DocumentMigrator.cs" />
     <Compile Include="..\passwordapp.api\Common\VaultBackupImporter.cs" Link="Common\VaultBackupImporter.cs" />
+    <Compile Include="..\passwordapp.api\Common\BackupSettingsValidator.cs" Link="Common\BackupSettingsValidator.cs" />
+    <Compile Include="..\passwordapp.api\Common\VaultBackupArchive.cs" Link="Common\VaultBackupArchive.cs" />
+    <Compile Include="..\passwordapp.api\Common\VaultBackupScheduler.cs" Link="Common\VaultBackupScheduler.cs" />
     <Compile Include="..\passwordapp.api\Common\BlueGreenVaultTransformer.cs" Link="Common\BlueGreenVaultTransformer.cs" />
     <Compile Include="..\passwordapp.api\Common\EntraTokenAuth.cs" Link="Common\EntraTokenAuth.cs" />
     <Compile Include="..\passwordapp.api\Common\E2eeFeature.cs" Link="Common\E2eeFeature.cs" />
     <Compile Include="..\passwordapp.api\Common\VaultKeyRecordValidator.cs" Link="Common\VaultKeyRecordValidator.cs" />
     <Compile Include="..\passwordapp.api\Models\AccountPasswords.cs" Link="Models\AccountPasswords.cs" />
     <Compile Include="..\passwordapp.api\Models\VaultKeyRecord.cs" Link="Models\VaultKeyRecord.cs" />
+    <Compile Include="..\passwordapp.api\Models\BackupSettingsRecord.cs" Link="Models\BackupSettingsRecord.cs" />
     <Compile Include="..\passwordapp.api\Models\PasswordHistory.cs" Link="Models\PasswordHistory.cs" />
     <Compile Include="..\passwordapp.api\Models\PasswordEntity.cs" Link="Models\PasswordEntity.cs" />
     <Compile Include="..\passwordapp.api\Models\Questions.cs" Link="Models\Questions.cs" />

--- a/src/passwordapp.api/Common/BackupSettingsValidator.cs
+++ b/src/passwordapp.api/Common/BackupSettingsValidator.cs
@@ -1,0 +1,58 @@
+using PasswordService.Models;
+
+namespace PasswordService.Common
+{
+    public static class BackupSettingsValidator
+    {
+        private static readonly HashSet<string> Frequencies = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "daily",
+            "weekly",
+            "monthly",
+        };
+
+        public static string? Validate(BackupSettingsRecord? settings)
+        {
+            if (settings is null)
+            {
+                return "Backup settings are required.";
+            }
+
+            if (!Frequencies.Contains(settings.Frequency))
+            {
+                return "Frequency must be daily, weekly, or monthly.";
+            }
+
+            if (!TimeOnly.TryParse(settings.TimeOfDay, out _))
+            {
+                return "TimeOfDay must be HH:mm.";
+            }
+
+            if (settings.DayOfMonth < 1 || settings.DayOfMonth > 31)
+            {
+                return "DayOfMonth must be between 1 and 31.";
+            }
+
+            if (settings.RetentionCount < 1 || settings.RetentionCount > 365)
+            {
+                return "RetentionCount must be between 1 and 365.";
+            }
+
+            return null;
+        }
+
+        public static BackupSettingsRecord Defaults(string partitionKey) => new()
+        {
+            id = BackupSettingsRecord.RecordId,
+            PartitionKey = partitionKey,
+            Enabled = false,
+            Frequency = "daily",
+            TimeOfDay = "02:00",
+            TimeZoneId = "UTC",
+            DayOfWeek = DayOfWeek.Sunday,
+            DayOfMonth = 1,
+            RetentionCount = 30,
+            LastStatus = "Not configured",
+        };
+    }
+}

--- a/src/passwordapp.api/Common/VaultBackupArchive.cs
+++ b/src/passwordapp.api/Common/VaultBackupArchive.cs
@@ -1,0 +1,38 @@
+using System.IO.Compression;
+using Newtonsoft.Json;
+using PasswordService.Models;
+
+namespace PasswordService.Common
+{
+    public sealed record VaultBackupArchiveResult(string BlobName, byte[] ZipBytes, int DocumentCount);
+
+    public static class VaultBackupArchive
+    {
+        public static VaultBackupArchiveResult Create(IEnumerable<AccountPassword> accounts, DateTimeOffset createdAt)
+        {
+            var documents = accounts?.ToList() ?? new List<AccountPassword>();
+            var blobName = $"vault-backups/vault-backup-{createdAt:yyyyMMdd-HHmmss}.zip";
+
+            using var output = new MemoryStream();
+            using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                WriteEntry(archive, "passwords.json", JsonConvert.SerializeObject(documents, Formatting.Indented));
+                WriteEntry(archive, "manifest.json", JsonConvert.SerializeObject(new
+                {
+                    createdAtUtc = createdAt.UtcDateTime,
+                    documentCount = documents.Count,
+                    passwordsRemainEncrypted = true,
+                }, Formatting.Indented));
+            }
+
+            return new VaultBackupArchiveResult(blobName, output.ToArray(), documents.Count);
+        }
+
+        private static void WriteEntry(ZipArchive archive, string name, string content)
+        {
+            var entry = archive.CreateEntry(name, CompressionLevel.Optimal);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(content);
+        }
+    }
+}

--- a/src/passwordapp.api/Common/VaultBackupBlobStore.cs
+++ b/src/passwordapp.api/Common/VaultBackupBlobStore.cs
@@ -1,0 +1,41 @@
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+namespace PasswordService.Common
+{
+    public sealed class VaultBackupBlobStore
+    {
+        private readonly string _accountName;
+        private readonly string _containerName;
+
+        public VaultBackupBlobStore(string accountName, string containerName)
+        {
+            _accountName = accountName;
+            _containerName = containerName;
+        }
+
+        public async Task UploadAsync(string blobName, byte[] zipBytes, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(_accountName))
+            {
+                throw new InvalidOperationException("BACKUP_STORAGE_ACCOUNT_NAME is not configured.");
+            }
+
+            if (string.IsNullOrWhiteSpace(_containerName))
+            {
+                throw new InvalidOperationException("BACKUP_STORAGE_CONTAINER_NAME is not configured.");
+            }
+
+            var service = new BlobServiceClient(
+                new Uri($"https://{_accountName}.blob.core.windows.net"),
+                new DefaultAzureCredential());
+            var container = service.GetBlobContainerClient(_containerName);
+            await container.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+
+            var blob = container.GetBlobClient(blobName);
+            await using var stream = new MemoryStream(zipBytes);
+            await blob.UploadAsync(stream, overwrite: false, cancellationToken);
+        }
+    }
+}

--- a/src/passwordapp.api/Common/VaultBackupScheduler.cs
+++ b/src/passwordapp.api/Common/VaultBackupScheduler.cs
@@ -1,0 +1,114 @@
+using PasswordService.Models;
+
+namespace PasswordService.Common
+{
+    public static class VaultBackupScheduler
+    {
+        public static bool ShouldRun(BackupSettingsRecord settings, DateTimeOffset utcNow)
+        {
+            if (!settings.Enabled)
+            {
+                return false;
+            }
+
+            var due = LatestDueAtOrBefore(settings, utcNow);
+            if (due is null)
+            {
+                return false;
+            }
+
+            return settings.LastBackupAt is null ||
+                   new DateTimeOffset(DateTime.SpecifyKind(settings.LastBackupAt.Value, DateTimeKind.Utc)) < due.Value;
+        }
+
+        public static DateTimeOffset? LatestDueAtOrBefore(BackupSettingsRecord settings, DateTimeOffset utcNow)
+        {
+            if (!TimeOnly.TryParse(settings.TimeOfDay, out var time))
+            {
+                return null;
+            }
+
+            var zone = ResolveTimeZone(settings.TimeZoneId);
+            var localNow = TimeZoneInfo.ConvertTime(utcNow, zone);
+
+            return settings.Frequency.ToLowerInvariant() switch
+            {
+                "daily" => Candidate(localNow.Date),
+                "weekly" => LatestWeekly(settings, localNow),
+                "monthly" => LatestMonthly(settings, localNow),
+                _ => null,
+            };
+
+            DateTimeOffset? Candidate(DateTime date)
+            {
+                var localDue = date.Add(time.ToTimeSpan());
+                if (localDue > localNow.DateTime)
+                {
+                    return null;
+                }
+                return TimeZoneInfo.ConvertTimeToUtc(localDue, zone);
+            }
+        }
+
+        private static DateTimeOffset? LatestWeekly(BackupSettingsRecord settings, DateTimeOffset localNow)
+        {
+            var daysSince = ((int)localNow.DayOfWeek - (int)settings.DayOfWeek + 7) % 7;
+            var date = localNow.Date.AddDays(-daysSince);
+            var due = DailyDue(settings, date, localNow);
+            return due ?? DailyDue(settings, date.AddDays(-7), localNow);
+        }
+
+        private static DateTimeOffset? LatestMonthly(BackupSettingsRecord settings, DateTimeOffset localNow)
+        {
+            var day = Math.Min(settings.DayOfMonth, DateTime.DaysInMonth(localNow.Year, localNow.Month));
+            var date = new DateTime(localNow.Year, localNow.Month, day);
+            var due = DailyDue(settings, date, localNow);
+            if (due is not null)
+            {
+                return due;
+            }
+
+            var priorMonth = localNow.AddMonths(-1);
+            day = Math.Min(settings.DayOfMonth, DateTime.DaysInMonth(priorMonth.Year, priorMonth.Month));
+            return DailyDue(settings, new DateTime(priorMonth.Year, priorMonth.Month, day), localNow);
+        }
+
+        private static DateTimeOffset? DailyDue(BackupSettingsRecord settings, DateTime date, DateTimeOffset localNow)
+        {
+            if (!TimeOnly.TryParse(settings.TimeOfDay, out var time))
+            {
+                return null;
+            }
+
+            var zone = ResolveTimeZone(settings.TimeZoneId);
+            var localDue = date.Add(time.ToTimeSpan());
+            if (localDue > localNow.DateTime)
+            {
+                return null;
+            }
+
+            return TimeZoneInfo.ConvertTimeToUtc(localDue, zone);
+        }
+
+        private static TimeZoneInfo ResolveTimeZone(string? timeZoneId)
+        {
+            if (string.IsNullOrWhiteSpace(timeZoneId))
+            {
+                return TimeZoneInfo.Utc;
+            }
+
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                return TimeZoneInfo.Utc;
+            }
+            catch (InvalidTimeZoneException)
+            {
+                return TimeZoneInfo.Utc;
+            }
+        }
+    }
+}

--- a/src/passwordapp.api/Functions/GetBackupSettings.cs
+++ b/src/passwordapp.api/Functions/GetBackupSettings.cs
@@ -1,0 +1,19 @@
+namespace PasswordService.API
+{
+    public partial class PasswordService
+    {
+        [Function(nameof(GetBackupSettings))]
+        public IActionResult GetBackupSettings(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "backup-settings")] HttpRequestData req,
+            [CosmosDBInput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_KEY_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
+                Connection = "COSMOSDB",
+                Id = BackupSettingsRecord.RecordId)] BackupSettingsRecord? settings)
+        {
+            _logger.LogInformation("GetBackupSettings request received");
+            return new OkObjectResult(settings ?? BackupSettingsValidator.Defaults(_keyPartitionKey));
+        }
+    }
+}

--- a/src/passwordapp.api/Functions/PutBackupSettings.cs
+++ b/src/passwordapp.api/Functions/PutBackupSettings.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using Newtonsoft.Json;
+
+namespace PasswordService.API
+{
+    public partial class PasswordService
+    {
+        public class PutBackupSettingsOutput
+        {
+            [CosmosDBOutput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_KEY_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
+                Connection = "COSMOSDB")]
+            public BackupSettingsRecord? Record { get; set; }
+
+            [HttpResult]
+            public HttpResponseData Response { get; set; } = default!;
+        }
+
+        [Function(nameof(PutBackupSettings))]
+        public async Task<PutBackupSettingsOutput> PutBackupSettings(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "backup-settings")] HttpRequestData req,
+            [CosmosDBInput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_KEY_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
+                Connection = "COSMOSDB",
+                Id = BackupSettingsRecord.RecordId)] BackupSettingsRecord? existing)
+        {
+            _logger.LogInformation("PutBackupSettings request received");
+
+            var body = await req.ReadAsStringAsync();
+            BackupSettingsRecord? posted = null;
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                try { posted = JsonConvert.DeserializeObject<BackupSettingsRecord>(body); }
+                catch (JsonException) { posted = null; }
+            }
+
+            var error = BackupSettingsValidator.Validate(posted);
+            if (error is not null)
+            {
+                return new PutBackupSettingsOutput { Response = await TextResponse(req, HttpStatusCode.BadRequest, error) };
+            }
+
+            posted!.id = BackupSettingsRecord.RecordId;
+            posted.PartitionKey = _keyPartitionKey;
+            posted.LastModifiedDate = DateTime.UtcNow;
+            posted.LastBackupAt = existing?.LastBackupAt;
+            posted.LastBackupBlobName = existing?.LastBackupBlobName;
+            posted.LastCheckedAt = existing?.LastCheckedAt;
+            posted.LastStatus = existing?.LastStatus;
+            posted.LastError = existing?.LastError;
+
+            var ok = req.CreateResponse(HttpStatusCode.OK);
+            await ok.WriteAsJsonAsync(posted);
+            return new PutBackupSettingsOutput { Record = posted, Response = ok };
+        }
+    }
+}

--- a/src/passwordapp.api/Functions/RunScheduledVaultBackup.cs
+++ b/src/passwordapp.api/Functions/RunScheduledVaultBackup.cs
@@ -1,0 +1,77 @@
+namespace PasswordService.API
+{
+    public partial class PasswordService
+    {
+        public class RunScheduledVaultBackupOutput
+        {
+            [CosmosDBOutput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_KEY_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
+                Connection = "COSMOSDB")]
+            public BackupSettingsRecord? Settings { get; set; }
+        }
+
+        [Function(nameof(RunScheduledVaultBackup))]
+        public async Task<RunScheduledVaultBackupOutput> RunScheduledVaultBackup(
+            [TimerTrigger("%BACKUP_TIMER_SCHEDULE%")] TimerInfo timer,
+            [CosmosDBInput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_PARTITION_KEY%",
+                Connection = "COSMOSDB")] IReadOnlyList<AccountPassword> passwordCollection,
+            [CosmosDBInput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_KEY_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
+                Connection = "COSMOSDB",
+                Id = BackupSettingsRecord.RecordId)] BackupSettingsRecord? settings)
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (settings is null || !settings.Enabled)
+            {
+                _logger.LogInformation("Scheduled vault backup skipped because backups are not enabled.");
+                return new RunScheduledVaultBackupOutput();
+            }
+
+            settings.id = BackupSettingsRecord.RecordId;
+            settings.PartitionKey = _keyPartitionKey;
+            settings.LastCheckedAt = now.UtcDateTime;
+
+            if (BackupSettingsValidator.Validate(settings) is { } validationError)
+            {
+                settings.LastStatus = "Invalid settings";
+                settings.LastError = validationError;
+                _logger.LogWarning("Scheduled vault backup skipped: {Reason}", validationError);
+                return new RunScheduledVaultBackupOutput { Settings = settings };
+            }
+
+            if (!VaultBackupScheduler.ShouldRun(settings, now))
+            {
+                _logger.LogInformation("Scheduled vault backup is not due.");
+                return new RunScheduledVaultBackupOutput();
+            }
+
+            try
+            {
+                var archive = VaultBackupArchive.Create(passwordCollection, now);
+                var store = new VaultBackupBlobStore(_backupStorageAccountName, _backupStorageContainerName);
+                await store.UploadAsync(archive.BlobName, archive.ZipBytes, CancellationToken.None);
+
+                settings.LastBackupAt = now.UtcDateTime;
+                settings.LastBackupBlobName = archive.BlobName;
+                settings.LastStatus = $"Backed up {archive.DocumentCount} document(s).";
+                settings.LastError = null;
+                _logger.LogInformation("Scheduled vault backup wrote {BlobName} with {DocumentCount} document(s).", archive.BlobName, archive.DocumentCount);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or Azure.RequestFailedException)
+            {
+                settings.LastStatus = "Backup failed";
+                settings.LastError = ex.Message;
+                _logger.LogError(ex, "Scheduled vault backup failed.");
+            }
+
+            return new RunScheduledVaultBackupOutput { Settings = settings };
+        }
+    }
+}

--- a/src/passwordapp.api/Models/BackupSettingsRecord.cs
+++ b/src/passwordapp.api/Models/BackupSettingsRecord.cs
@@ -1,0 +1,23 @@
+namespace PasswordService.Models
+{
+    public class BackupSettingsRecord
+    {
+        public const string RecordId = "backup-settings";
+
+        public string? id { get; set; } = RecordId;
+        public string? PartitionKey { get; set; }
+        public bool Enabled { get; set; }
+        public string Frequency { get; set; } = "daily";
+        public string TimeOfDay { get; set; } = "02:00";
+        public string TimeZoneId { get; set; } = "UTC";
+        public DayOfWeek DayOfWeek { get; set; } = DayOfWeek.Sunday;
+        public int DayOfMonth { get; set; } = 1;
+        public int RetentionCount { get; set; } = 30;
+        public DateTime? LastBackupAt { get; set; }
+        public string? LastBackupBlobName { get; set; }
+        public DateTime? LastCheckedAt { get; set; }
+        public string? LastStatus { get; set; }
+        public string? LastError { get; set; }
+        public DateTime LastModifiedDate { get; set; }
+    }
+}

--- a/src/passwordapp.api/PasswordService.cs
+++ b/src/passwordapp.api/PasswordService.cs
@@ -5,6 +5,9 @@ namespace PasswordService.API
     {
         private ILogger<PasswordService> _logger;
         private string _partitionKey;
+        private string _keyPartitionKey;
+        private string _backupStorageAccountName;
+        private string _backupStorageContainerName;
 
         private Encryptor _encryptor; 
 
@@ -16,6 +19,9 @@ namespace PasswordService.API
                 Environment.GetEnvironmentVariable("AesIV", EnvironmentVariableTarget.Process) ?? string.Empty
             );
             _partitionKey = Environment.GetEnvironmentVariable("COSMOS_PARTITION_KEY", EnvironmentVariableTarget.Process) ?? string.Empty;
+            _keyPartitionKey = Environment.GetEnvironmentVariable("COSMOS_KEY_PARTITION_KEY", EnvironmentVariableTarget.Process) ?? "VaultKeys";
+            _backupStorageAccountName = Environment.GetEnvironmentVariable("BACKUP_STORAGE_ACCOUNT_NAME", EnvironmentVariableTarget.Process) ?? string.Empty;
+            _backupStorageContainerName = Environment.GetEnvironmentVariable("BACKUP_STORAGE_CONTAINER_NAME", EnvironmentVariableTarget.Process) ?? "vault-backups";
         }
     }
 }

--- a/src/passwordapp.api/PasswordService.csproj
+++ b/src/passwordapp.api/PasswordService.csproj
@@ -18,7 +18,10 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.16.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.16.0" />
   </ItemGroup>    

--- a/src/passwordapp.ui/src/components/api/BackupSettings.Api.js
+++ b/src/passwordapp.ui/src/components/api/BackupSettings.Api.js
@@ -1,0 +1,63 @@
+import Axios from 'axios';
+
+const API_ENDPOINT = '/api/backup-settings';
+
+export const defaultBackupSettings = () => ({
+  enabled: false,
+  frequency: 'daily',
+  timeOfDay: '02:00',
+  timeZoneId: 'UTC',
+  dayOfWeek: 0,
+  dayOfMonth: 1,
+  retentionCount: 30,
+  lastBackupAt: null,
+  lastBackupBlobName: '',
+  lastCheckedAt: null,
+  lastStatus: 'Not configured',
+  lastError: '',
+});
+
+export function normalizeBackupSettings(record) {
+  const defaults = defaultBackupSettings();
+  if (!record) {
+    return defaults;
+  }
+
+  return {
+    enabled: record.enabled ?? record.Enabled ?? defaults.enabled,
+    frequency: record.frequency ?? record.Frequency ?? defaults.frequency,
+    timeOfDay: record.timeOfDay ?? record.TimeOfDay ?? defaults.timeOfDay,
+    timeZoneId: record.timeZoneId ?? record.TimeZoneId ?? defaults.timeZoneId,
+    dayOfWeek: record.dayOfWeek ?? record.DayOfWeek ?? defaults.dayOfWeek,
+    dayOfMonth: record.dayOfMonth ?? record.DayOfMonth ?? defaults.dayOfMonth,
+    retentionCount: record.retentionCount ?? record.RetentionCount ?? defaults.retentionCount,
+    lastBackupAt: record.lastBackupAt ?? record.LastBackupAt ?? defaults.lastBackupAt,
+    lastBackupBlobName: record.lastBackupBlobName ?? record.LastBackupBlobName ?? defaults.lastBackupBlobName,
+    lastCheckedAt: record.lastCheckedAt ?? record.LastCheckedAt ?? defaults.lastCheckedAt,
+    lastStatus: record.lastStatus ?? record.LastStatus ?? defaults.lastStatus,
+    lastError: record.lastError ?? record.LastError ?? defaults.lastError,
+  };
+}
+
+function toServerRecord(settings) {
+  const normalized = normalizeBackupSettings(settings);
+  return {
+    Enabled: Boolean(normalized.enabled),
+    Frequency: normalized.frequency,
+    TimeOfDay: normalized.timeOfDay,
+    TimeZoneId: normalized.timeZoneId,
+    DayOfWeek: Number(normalized.dayOfWeek),
+    DayOfMonth: Number(normalized.dayOfMonth),
+    RetentionCount: Number(normalized.retentionCount),
+  };
+}
+
+export async function getBackupSettings(http = Axios) {
+  const response = await http.get(API_ENDPOINT);
+  return normalizeBackupSettings(response.data);
+}
+
+export async function putBackupSettings(settings, http = Axios) {
+  const response = await http.put(API_ENDPOINT, toServerRecord(settings));
+  return normalizeBackupSettings(response.data);
+}

--- a/src/passwordapp.ui/src/components/settings/settings.js
+++ b/src/passwordapp.ui/src/components/settings/settings.js
@@ -5,12 +5,20 @@ import {
   saveSettings,
   resetSettings,
 } from '@/components/settings/settings.store.js';
+import {
+  defaultBackupSettings,
+  getBackupSettings,
+  putBackupSettings,
+} from '@/components/api/BackupSettings.Api.js';
 
 export default {
   name: 'Settings',
   data() {
     return {
       settings: loadSettings(Authentication.getUserProfile()),
+      backupSettings: defaultBackupSettings(),
+      backupSettingsError: '',
+      backupSettingsLoading: false,
       savedMessage: '',
       separatorChoices: [
         { value: '-', text: 'Dash ( - )' },
@@ -49,6 +57,22 @@ export default {
         { value: 15, text: '15 minutes' },
         { value: 30, text: '30 minutes' },
       ],
+      backupFrequencyChoices: [
+        { value: 'daily', text: 'Daily' },
+        { value: 'weekly', text: 'Weekly' },
+        { value: 'monthly', text: 'Monthly' },
+      ],
+      dayOfWeekChoices: [
+        { value: 0, text: 'Sunday' },
+        { value: 1, text: 'Monday' },
+        { value: 2, text: 'Tuesday' },
+        { value: 3, text: 'Wednesday' },
+        { value: 4, text: 'Thursday' },
+        { value: 5, text: 'Friday' },
+        { value: 6, text: 'Saturday' },
+      ],
+      dayOfMonthChoices: Array.from({ length: 31 }, (_, i) => i + 1),
+      retentionChoices: [7, 14, 30, 60, 90, 180, 365],
     };
   },
   computed: {
@@ -62,13 +86,31 @@ export default {
       }
     },
   },
+  async mounted() {
+    this.backupSettingsLoading = true;
+    this.backupSettingsError = '';
+    try {
+      this.backupSettings = await getBackupSettings();
+    } catch (err) {
+      this.backupSettingsError = 'Unable to load backup schedule: ' + (err && err.message ? err.message : err);
+    } finally {
+      this.backupSettingsLoading = false;
+    }
+  },
   methods: {
-    save() {
+    async save() {
       const userId = Authentication.getUserProfile();
       const ok = saveSettings(userId, this.settings);
-      this.savedMessage = ok
-        ? 'Preferences saved.'
-        : 'Could not save preferences (storage unavailable).';
+      try {
+        this.backupSettings = await putBackupSettings(this.backupSettings);
+        this.backupSettingsError = '';
+        this.savedMessage = ok
+          ? 'Preferences and backup schedule saved.'
+          : 'Backup schedule saved. Could not save local preferences (storage unavailable).';
+      } catch (err) {
+        this.savedMessage = ok ? 'Preferences saved.' : 'Could not save preferences (storage unavailable).';
+        this.backupSettingsError = 'Could not save backup schedule: ' + (err && err.message ? err.message : err);
+      }
     },
     resetToDefaults() {
       const userId = Authentication.getUserProfile();

--- a/src/passwordapp.ui/src/components/settings/settings.vue
+++ b/src/passwordapp.ui/src/components/settings/settings.vue
@@ -92,6 +92,57 @@
       </div>
     </div>
 
+    <!-- Backups -->
+    <div class="card mb-3">
+      <div class="card-header">Encrypted Vault Backups</div>
+      <div class="card-body">
+        <p class="mb-3">
+          Schedule a server-side export of all Cosmos password documents to private blob storage.
+          Password fields stay encrypted; the backup is zipped before upload.
+        </p>
+
+        <div class="row mb-2">
+          <label class="col-4 col-form-label">Scheduled backups:</label>
+          <div class="col d-flex align-items-center">
+            <Checkbox v-model="backupSettings.enabled" :binary="true" inputId="backup-enabled" />
+            <label for="backup-enabled" class="ms-2">Enabled</label>
+          </div>
+        </div>
+        <div class="row mb-2">
+          <label class="col-4 col-form-label">Frequency:</label>
+          <div class="col"><Select v-model="backupSettings.frequency" :options="backupFrequencyChoices" optionLabel="text" optionValue="value" size="small" class="vault-select" /></div>
+        </div>
+        <div v-if="backupSettings.frequency === 'weekly'" class="row mb-2">
+          <label class="col-4 col-form-label">Day of week:</label>
+          <div class="col"><Select v-model="backupSettings.dayOfWeek" :options="dayOfWeekChoices" optionLabel="text" optionValue="value" size="small" class="vault-select" /></div>
+        </div>
+        <div v-if="backupSettings.frequency === 'monthly'" class="row mb-2">
+          <label class="col-4 col-form-label">Day of month:</label>
+          <div class="col"><Select v-model="backupSettings.dayOfMonth" :options="dayOfMonthChoices" size="small" class="vault-select" /></div>
+        </div>
+        <div class="row mb-2">
+          <label class="col-4 col-form-label">Time:</label>
+          <div class="col"><InputText v-model="backupSettings.timeOfDay" type="time" size="small" class="vault-select" /></div>
+        </div>
+        <div class="row mb-2">
+          <label class="col-4 col-form-label">Time zone:</label>
+          <div class="col"><InputText v-model="backupSettings.timeZoneId" size="small" class="vault-select" placeholder="UTC" /></div>
+        </div>
+        <div class="row mb-2">
+          <label class="col-4 col-form-label">Keep backups:</label>
+          <div class="col"><Select v-model="backupSettings.retentionCount" :options="retentionChoices" size="small" class="vault-select" /></div>
+        </div>
+
+        <small class="text-muted d-block">
+          Timer checks run every 15 minutes, then apply this schedule. Last status:
+          {{ backupSettings.lastStatus || 'Not configured' }}
+          <span v-if="backupSettings.lastBackupBlobName">({{ backupSettings.lastBackupBlobName }})</span>
+        </small>
+        <Message v-if="backupSettingsError" severity="error" class="mt-2 py-2">{{ backupSettingsError }}</Message>
+        <Message v-else-if="backupSettingsLoading" severity="info" class="mt-2 py-2">Loading backup schedule...</Message>
+      </div>
+    </div>
+
     <div class="row">
       <div class="col d-flex gap-2">
         <Button size="small" severity="info" label="Save" @click.stop="save()" />

--- a/src/passwordapp.ui/tests/unit/backup-settings-api.spec.js
+++ b/src/passwordapp.ui/tests/unit/backup-settings-api.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defaultBackupSettings,
+  normalizeBackupSettings,
+  getBackupSettings,
+  putBackupSettings,
+} from '@/components/api/BackupSettings.Api.js';
+
+describe('backup settings API helper', () => {
+  it('normalizes PascalCase server settings', () => {
+    const normalized = normalizeBackupSettings({
+      Enabled: true,
+      Frequency: 'weekly',
+      TimeOfDay: '23:15',
+      TimeZoneId: 'UTC',
+      DayOfWeek: 4,
+      DayOfMonth: 12,
+      RetentionCount: 10,
+      LastStatus: 'Backed up 10 document(s).',
+    });
+
+    expect(normalized).toMatchObject({
+      enabled: true,
+      frequency: 'weekly',
+      timeOfDay: '23:15',
+      dayOfWeek: 4,
+      dayOfMonth: 12,
+      retentionCount: 10,
+      lastStatus: 'Backed up 10 document(s).',
+    });
+  });
+
+  it('returns defaults for empty records', () => {
+    expect(normalizeBackupSettings(null)).toEqual(defaultBackupSettings());
+  });
+
+  it('GETs /api/backup-settings', async () => {
+    const http = {
+      async get(url) {
+        return { data: { Enabled: true, Frequency: 'daily', TimeOfDay: '01:00' }, url };
+      },
+    };
+
+    await expect(getBackupSettings(http)).resolves.toMatchObject({ enabled: true, timeOfDay: '01:00' });
+  });
+
+  it('PUTs normalized server payload', async () => {
+    const sent = [];
+    const http = {
+      async put(url, body) {
+        sent.push({ url, body });
+        return { data: body };
+      },
+    };
+
+    await putBackupSettings({ enabled: true, frequency: 'monthly', dayOfMonth: '15', retentionCount: '20' }, http);
+
+    expect(sent).toEqual([{
+      url: '/api/backup-settings',
+      body: {
+        Enabled: true,
+        Frequency: 'monthly',
+        TimeOfDay: '02:00',
+        TimeZoneId: 'UTC',
+        DayOfWeek: 0,
+        DayOfMonth: 15,
+        RetentionCount: 20,
+      },
+    }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add API-hosted scheduled encrypted vault backups that zip Cosmos password documents without decrypting secrets
- persist backup schedule/status through secured backup settings endpoints and expose controls in Settings
- provision the private vault-backups storage container and Function App backup timer settings
- document the backup architecture and future maintenance-project replacement path

## Validation
- dotnet test src\\passwordapp.api.tests\\passwordapp.api.tests.csproj --nologo
- dotnet build src\\passwordapp.api\\PasswordService.csproj -c Release --nologo
- npm.cmd --prefix src\\passwordapp.ui run lint
- npm.cmd --prefix src\\passwordapp.ui run test:unit
- npm.cmd --prefix src\\passwordapp.ui run build
- terraform init -backend=false -input=false; terraform fmt -check -recursive; terraform validate