### PR TITLE
Add PWA layout and manual backup trigger

### DIFF
--- a/src/passwordapp.api/Functions/RunScheduledVaultBackup.cs
+++ b/src/passwordapp.api/Functions/RunScheduledVaultBackup.cs
@@ -54,15 +54,7 @@ namespace PasswordService.API
 
             try
             {
-                var archive = VaultBackupArchive.Create(passwordCollection, now);
-                var store = new VaultBackupBlobStore(_backupStorageAccountName, _backupStorageContainerName);
-                await store.UploadAsync(archive.BlobName, archive.ZipBytes, CancellationToken.None);
-
-                settings.LastBackupAt = now.UtcDateTime;
-                settings.LastBackupBlobName = archive.BlobName;
-                settings.LastStatus = $"Backed up {archive.DocumentCount} document(s).";
-                settings.LastError = null;
-                _logger.LogInformation("Scheduled vault backup wrote {BlobName} with {DocumentCount} document(s).", archive.BlobName, archive.DocumentCount);
+                await CreateVaultBackupAsync(passwordCollection, settings, now, "Scheduled vault backup");
             }
             catch (Exception ex) when (ex is InvalidOperationException or Azure.RequestFailedException)
             {
@@ -72,6 +64,23 @@ namespace PasswordService.API
             }
 
             return new RunScheduledVaultBackupOutput { Settings = settings };
+        }
+
+        private async Task CreateVaultBackupAsync(
+            IReadOnlyList<AccountPassword> passwordCollection,
+            BackupSettingsRecord settings,
+            DateTimeOffset now,
+            string operationName)
+        {
+            var archive = VaultBackupArchive.Create(passwordCollection, now);
+            var store = new VaultBackupBlobStore(_backupStorageAccountName, _backupStorageContainerName);
+            await store.UploadAsync(archive.BlobName, archive.ZipBytes, CancellationToken.None);
+
+            settings.LastBackupAt = now.UtcDateTime;
+            settings.LastBackupBlobName = archive.BlobName;
+            settings.LastStatus = $"Backed up {archive.DocumentCount} document(s).";
+            settings.LastError = null;
+            _logger.LogInformation("{OperationName} wrote {BlobName} with {DocumentCount} document(s).", operationName, archive.BlobName, archive.DocumentCount);
         }
     }
 }

--- a/src/passwordapp.api/Functions/RunVaultBackupNow.cs
+++ b/src/passwordapp.api/Functions/RunVaultBackupNow.cs
@@ -1,0 +1,83 @@
+using System.Net;
+
+namespace PasswordService.API
+{
+    public partial class PasswordService
+    {
+        public class RunVaultBackupNowOutput
+        {
+            [CosmosDBOutput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_KEY_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
+                Connection = "COSMOSDB")]
+            public BackupSettingsRecord? Settings { get; set; }
+
+            [HttpResult]
+            public HttpResponseData Response { get; set; } = default!;
+        }
+
+        [Function(nameof(RunVaultBackupNow))]
+        public async Task<RunVaultBackupNowOutput> RunVaultBackupNow(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "backup-settings/run-now")] HttpRequestData req,
+            [CosmosDBInput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_PARTITION_KEY%",
+                Connection = "COSMOSDB")] IReadOnlyList<AccountPassword> passwordCollection,
+            [CosmosDBInput(
+                "%COSMOS_DATABASE_NAME%",
+                "%COSMOS_KEY_COLLECTION_NAME%",
+                PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
+                Connection = "COSMOSDB",
+                Id = BackupSettingsRecord.RecordId)] BackupSettingsRecord? settings)
+        {
+            _logger.LogInformation("RunVaultBackupNow request received");
+
+            var now = DateTimeOffset.UtcNow;
+            settings ??= BackupSettingsValidator.Defaults(_keyPartitionKey);
+            settings.id = BackupSettingsRecord.RecordId;
+            settings.PartitionKey = _keyPartitionKey;
+            settings.LastCheckedAt = now.UtcDateTime;
+
+            if (BackupSettingsValidator.Validate(settings) is { } validationError)
+            {
+                settings.LastStatus = "Invalid settings";
+                settings.LastError = validationError;
+                return new RunVaultBackupNowOutput
+                {
+                    Settings = settings,
+                    Response = await JsonResponse(req, HttpStatusCode.BadRequest, settings),
+                };
+            }
+
+            try
+            {
+                await CreateVaultBackupAsync(passwordCollection, settings, now, "Manual vault backup");
+                return new RunVaultBackupNowOutput
+                {
+                    Settings = settings,
+                    Response = await JsonResponse(req, HttpStatusCode.OK, settings),
+                };
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or Azure.RequestFailedException)
+            {
+                settings.LastStatus = "Backup failed";
+                settings.LastError = ex.Message;
+                _logger.LogError(ex, "Manual vault backup failed.");
+                return new RunVaultBackupNowOutput
+                {
+                    Settings = settings,
+                    Response = await JsonResponse(req, HttpStatusCode.InternalServerError, settings),
+                };
+            }
+        }
+
+        private static async Task<HttpResponseData> JsonResponse(HttpRequestData req, HttpStatusCode statusCode, BackupSettingsRecord settings)
+        {
+            var response = req.CreateResponse(statusCode);
+            await response.WriteAsJsonAsync(settings);
+            return response;
+        }
+    }
+}

--- a/src/passwordapp.ui/src/App.vue
+++ b/src/passwordapp.ui/src/App.vue
@@ -5,7 +5,16 @@
         <h1>The Vault</h1>
         <span>Members only</span>
       </div>
-      <nav class="vault-nav" aria-label="Vault navigation">
+      <button
+        class="vault-menu-toggle"
+        type="button"
+        :aria-expanded="navOpen ? 'true' : 'false'"
+        aria-controls="vault-navigation"
+        @click="toggleNav">
+        <font-awesome-icon icon="bars" />
+        Menu
+      </button>
+      <nav id="vault-navigation" class="vault-nav" :class="{ 'is-open': navOpen }" aria-label="Vault navigation" @click="closeNav">
         <template v-if="vaultUnlocked">
           <router-link :to="{ name: 'Home' }"><i class="pi pi-id-card"></i> Accounts</router-link>
           <router-link :to="{ name: 'Settings' }"><i class="pi pi-cog"></i> Settings</router-link>
@@ -45,6 +54,7 @@ export default {
   setup() {
     const savedDarkMode = localStorage.getItem('darkMode');
     const isDarkMode = ref(savedDarkMode === null ? true : savedDarkMode === 'true');
+    const navOpen = ref(false);
     const e2eeEnabled = isE2eeEnabled();
     const sessionState = ref({ isUnlocked: vaultSession.isUnlocked, unlockedAt: vaultSession.unlockedAt });
     const vaultUnlocked = computed(() => !e2eeEnabled || sessionState.value.isUnlocked);
@@ -61,6 +71,14 @@ export default {
 
     const logOut = () => {
       Authentication.signOut();
+    };
+
+    const toggleNav = () => {
+      navOpen.value = !navOpen.value;
+    };
+
+    const closeNav = () => {
+      navOpen.value = false;
     };
 
     if (isDarkMode.value) {
@@ -125,10 +143,13 @@ export default {
 
     return {
       isDarkMode,
+      navOpen,
       e2eeEnabled,
       sessionState,
       vaultUnlocked,
       toggleDarkMode,
+      toggleNav,
+      closeNav,
       logOut,
     };
   },

--- a/src/passwordapp.ui/src/components/api/BackupSettings.Api.js
+++ b/src/passwordapp.ui/src/components/api/BackupSettings.Api.js
@@ -61,3 +61,8 @@ export async function putBackupSettings(settings, http = Axios) {
   const response = await http.put(API_ENDPOINT, toServerRecord(settings));
   return normalizeBackupSettings(response.data);
 }
+
+export async function runBackupNow(http = Axios) {
+  const response = await http.post(`${API_ENDPOINT}/run-now`);
+  return normalizeBackupSettings(response.data);
+}

--- a/src/passwordapp.ui/src/components/home/home.css
+++ b/src/passwordapp.ui/src/components/home/home.css
@@ -2,3 +2,84 @@
 .site-name {
   max-width: 260px;
 }
+
+.vault-mobile-list {
+  display: none;
+}
+
+.vault-mobile-account {
+  overflow: hidden;
+  border: .5px solid var(--vault-border);
+  border-radius: .5rem;
+  background: var(--vault-surface);
+}
+
+.vault-mobile-account + .vault-mobile-account {
+  margin-top: .85rem;
+}
+
+.vault-mobile-account-row {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 38%) 1fr;
+  border-bottom: .5px solid var(--vault-border-soft);
+}
+
+.vault-mobile-account-label,
+.vault-mobile-account-value,
+.vault-mobile-account-actions {
+  min-width: 0;
+  padding: .65rem .75rem;
+}
+
+.vault-mobile-account-label {
+  background: color-mix(in srgb, var(--vault-surface-2) 70%, transparent);
+  color: var(--vault-text);
+  font-size: .8125rem;
+  font-weight: 700;
+  text-align: right;
+}
+
+.vault-mobile-account-value {
+  overflow-wrap: anywhere;
+  color: var(--vault-text);
+  font-size: .8125rem;
+}
+
+.vault-mobile-account-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+}
+
+.vault-mobile-details {
+  display: grid;
+  gap: .4rem;
+  padding: .75rem;
+  background: var(--vault-surface-2);
+  color: var(--vault-text);
+  font-size: .8125rem;
+}
+
+.vault-mobile-details b {
+  color: var(--vault-accent-strong);
+}
+
+.vault-mobile-empty {
+  margin: 1rem 0;
+  color: var(--vault-muted);
+}
+
+@media (max-width: 760px) {
+  .account-name,
+  .site-name {
+    max-width: 100%;
+  }
+
+  .vault-desktop-table {
+    display: none;
+  }
+
+  .vault-mobile-list {
+    display: block;
+  }
+}

--- a/src/passwordapp.ui/src/components/home/home.js
+++ b/src/passwordapp.ui/src/components/home/home.js
@@ -34,12 +34,22 @@ export default {
       }
       return list;
     },
+    sortedFilteredPasswords() {
+      const field = this.sortBy || 'accountName';
+      const direction = this.sortDesc ? -1 : 1;
+      return [...this.filteredPasswords].sort((left, right) =>
+        this.compareRows(left, right, field) * direction);
+    },
+    mobilePagedPasswords() {
+      return this.sortedFilteredPasswords.slice(this.mobileFirst, this.mobileFirst + this.perPage);
+    },
   },
   data() {
     const settings = loadSettings(Authentication.getUserProfile());
     return {
       passwords:    [],
       perPage:      settings.list.perPage,
+      mobileFirst:  0,
       filter:       '',
       selectedTag:  null,
       sortBy:       settings.list.sortBy,
@@ -60,6 +70,21 @@ export default {
 
   created() {
     this.fetchPasswords();
+  },
+
+  watch: {
+    filter() {
+      this.mobileFirst = 0;
+    },
+    selectedTag() {
+      this.mobileFirst = 0;
+    },
+    filteredPasswords(list) {
+      this.clampMobileFirst(list.length);
+    },
+    perPage() {
+      this.clampMobileFirst();
+    },
   },
 
   methods: {
@@ -83,6 +108,38 @@ export default {
         expanded[row.id] = true;
       }
       this.expandedRows = expanded;
+    },
+    isDetailsExpanded(row) {
+      return Boolean(this.expandedRows[row.id]);
+    },
+    onMobilePage(event) {
+      this.mobileFirst = event.first;
+      this.perPage = event.rows;
+    },
+    clampMobileFirst(total = this.filteredPasswords.length) {
+      if (total <= 0) {
+        this.mobileFirst = 0;
+        return;
+      }
+
+      if (this.mobileFirst >= total) {
+        this.mobileFirst = Math.floor((total - 1) / this.perPage) * this.perPage;
+      }
+    },
+    compareRows(left, right, field) {
+      const leftValue = this.sortValue(left && left[field], field);
+      const rightValue = this.sortValue(right && right[field], field);
+      if (typeof leftValue === 'number' && typeof rightValue === 'number') {
+        return leftValue - rightValue;
+      }
+      return String(leftValue).localeCompare(String(rightValue), undefined, { sensitivity: 'base' });
+    },
+    sortValue(value, field) {
+      if (field === 'lastModifiedDate') {
+        const time = Date.parse(value);
+        return Number.isFinite(time) ? time : 0;
+      }
+      return value ?? '';
     },
     updatePassword(passwordId) {
       this.$router.push({ name: 'Update', params: { id: passwordId } });

--- a/src/passwordapp.ui/src/components/home/home.vue
+++ b/src/passwordapp.ui/src/components/home/home.vue
@@ -28,7 +28,7 @@
       {{ apiError }}
     </Message>
 
-    <div class="row">
+    <div class="row vault-desktop-table">
       <div class="col-12">
         <DataTable
           :value="filteredPasswords"
@@ -95,9 +95,71 @@
                 <div class="row mb-2"><div class="col"><b>Notes:</b></div><div class="col">{{ data.notes }}</div></div>
               </div>
             </div>
+
           </template>
         </DataTable>
       </div>
+    </div>
+
+    <div class="vault-mobile-list" aria-label="Accounts">
+      <article v-for="password in mobilePagedPasswords" :key="password.id" class="vault-mobile-account">
+        <div class="vault-mobile-account-row">
+          <div class="vault-mobile-account-label">Account</div>
+          <div class="vault-mobile-account-value">
+            <span class="text-lowercase">{{ password.accountName }}</span>
+            <div v-if="tagsOf(password).length" class="mt-1">
+              <Tag v-for="tag in tagsOf(password)" :key="tag" :value="tag" severity="secondary" class="me-1 mb-1" @click.stop="selectedTag = tag" style="cursor: pointer;" />
+            </div>
+          </div>
+        </div>
+        <div class="vault-mobile-account-row">
+          <div class="vault-mobile-account-label">Site</div>
+          <div class="vault-mobile-account-value text-lowercase">{{ password.siteName }}</div>
+        </div>
+        <div class="vault-mobile-account-row">
+          <div class="vault-mobile-account-label">Last Modified</div>
+          <div class="vault-mobile-account-value">
+            <div>{{ formatDate(password.lastModifiedDate) }}</div>
+            <small
+              class="text-muted"
+              :class="{ 'fst-italic': isStaleRow(password) }">
+              {{ isStaleRow(password) ? staleAgeOf(password) : ageOf(password) }}
+            </small>
+          </div>
+        </div>
+        <div class="vault-mobile-account-row">
+          <div class="vault-mobile-account-label">Edit/Remove</div>
+          <div class="vault-mobile-account-actions">
+            <Button class="vault-icon-button" size="small" severity="success" @click.stop="copyPassword(password.id)" v-tooltip.top="'Copy'"><font-awesome-icon icon="copy" /></Button>
+            <Button class="vault-icon-button" size="small" @click.stop="displayPassword(password.id)" v-tooltip.top="'Reveal'"><font-awesome-icon icon="info" /></Button>
+            <Button class="vault-icon-button" size="small" severity="info" @click.stop="updatePassword(password.id)" v-tooltip.top="'Edit'"><font-awesome-icon icon="user-edit" /></Button>
+            <Button class="vault-icon-button" size="small" severity="contrast" @click.stop="toggleDetails(password)" v-tooltip.top="'Details'"><font-awesome-icon icon="bars" /></Button>
+            <Button class="vault-icon-button" size="small" severity="warn" @click.stop="showHistory(password.id)" v-tooltip.top="'History'"><font-awesome-icon :icon="['fas', 'clock-rotate-left']" /></Button>
+            <Button class="vault-icon-button" size="small" severity="danger" @click.stop="deletePassword(password.id)" v-tooltip.top="'Delete'"><font-awesome-icon icon="trash-alt" /></Button>
+          </div>
+        </div>
+        <div v-if="isDetailsExpanded(password)" class="vault-mobile-details">
+          <div><b>Created By:</b> {{ password.createdBy }}</div>
+          <div><b>Updated By:</b> {{ password.lastModifiedBy }}</div>
+          <div v-if="password.notes"><b>Notes:</b> {{ password.notes }}</div>
+          <div v-if="password.securityQuestions && password.securityQuestions.length">
+            <b>Security Questions:</b>
+            <div v-for="securityQuestion in password.securityQuestions" :key="securityQuestion.question">
+              <span v-if="securityQuestion.question !== '' && securityQuestion.answer !== ''">
+                <i>{{ securityQuestion.question }}</i>: {{ securityQuestion.answer }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </article>
+      <p v-if="filteredPasswords.length === 0" class="vault-mobile-empty">No accounts found.</p>
+      <Paginator
+        v-if="filteredPasswords.length > perPage"
+        :first="mobileFirst"
+        :rows="perPage"
+        :totalRecords="filteredPasswords.length"
+        :rowsPerPageOptions="[5, 10, 20, 50, 100]"
+        @page="onMobilePage" />
     </div>
 
     <Dialog v-model:visible="showDeleteModal" modal header="Confirm your action" :style="{ width: '30rem' }">

--- a/src/passwordapp.ui/src/components/settings/settings.js
+++ b/src/passwordapp.ui/src/components/settings/settings.js
@@ -8,7 +8,9 @@ import {
 import {
   defaultBackupSettings,
   getBackupSettings,
+  normalizeBackupSettings,
   putBackupSettings,
+  runBackupNow,
 } from '@/components/api/BackupSettings.Api.js';
 
 export default {
@@ -19,6 +21,7 @@ export default {
       backupSettings: defaultBackupSettings(),
       backupSettingsError: '',
       backupSettingsLoading: false,
+      backupRunningNow: false,
       savedMessage: '',
       separatorChoices: [
         { value: '-', text: 'Dash ( - )' },
@@ -116,6 +119,29 @@ export default {
       const userId = Authentication.getUserProfile();
       this.settings = resetSettings(userId);
       this.savedMessage = 'Preferences reset to defaults.';
+    },
+    async runBackupNow() {
+      this.backupRunningNow = true;
+      this.backupSettingsError = '';
+      this.savedMessage = '';
+      try {
+        this.backupSettings = await runBackupNow();
+        this.savedMessage = 'Backup completed.';
+      } catch (err) {
+        if (err && err.response && err.response.data) {
+          this.backupSettings = normalizeBackupSettings(err.response.data);
+        }
+        this.backupSettingsError = 'Could not run backup: ' + this.describeBackupError(err);
+      } finally {
+        this.backupRunningNow = false;
+      }
+    },
+    describeBackupError(err) {
+      const data = err && err.response && err.response.data;
+      if (data) {
+        return data.lastError || data.LastError || data.lastStatus || data.LastStatus || err.message;
+      }
+      return err && err.message ? err.message : err;
     },
   },
 };

--- a/src/passwordapp.ui/src/components/settings/settings.vue
+++ b/src/passwordapp.ui/src/components/settings/settings.vue
@@ -138,6 +138,16 @@
           {{ backupSettings.lastStatus || 'Not configured' }}
           <span v-if="backupSettings.lastBackupBlobName">({{ backupSettings.lastBackupBlobName }})</span>
         </small>
+        <div class="mt-3">
+          <Button
+            size="small"
+            severity="info"
+            label="Run Now"
+            icon="pi pi-play"
+            :loading="backupRunningNow"
+            :disabled="backupSettingsLoading || backupRunningNow"
+            @click.stop="runBackupNow()" />
+        </div>
         <Message v-if="backupSettingsError" severity="error" class="mt-2 py-2">{{ backupSettingsError }}</Message>
         <Message v-else-if="backupSettingsLoading" severity="info" class="mt-2 py-2">Loading backup schedule...</Message>
       </div>

--- a/src/passwordapp.ui/src/css/main.css
+++ b/src/passwordapp.ui/src/css/main.css
@@ -114,6 +114,23 @@ body {
   overflow-x: auto;
 }
 
+.vault-menu-toggle {
+  display: none;
+  align-items: center;
+  gap: .45rem;
+  min-height: 2.5rem;
+  margin: 1rem auto;
+  padding: .5rem 1rem;
+  border: .5px solid var(--vault-border);
+  border-radius: .5rem;
+  background: var(--vault-surface);
+  color: var(--vault-accent-strong);
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
 .vault-nav a,
 .vault-nav-button {
   display: inline-flex;
@@ -622,7 +639,53 @@ small.text-muted {
 
 @media (max-width: 760px) {
   .vault-brand {
-    padding-top: .8rem;
+    padding: 1rem 1rem 0;
+  }
+
+  .vault-brand h1 {
+    font-size: clamp(2.25rem, 14vw, 3.5rem);
+  }
+
+  .vault-brand span {
+    gap: .65rem;
+    letter-spacing: .24em;
+  }
+
+  .vault-brand span::before,
+  .vault-brand span::after {
+    width: 2.25rem;
+  }
+
+  .vault-menu-toggle {
+    display: inline-flex;
+  }
+
+  .vault-nav {
+    display: none;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0;
+    margin-top: 0;
+    padding: 0;
+    overflow-x: visible;
+  }
+
+  .vault-nav.is-open {
+    display: flex;
+  }
+
+  .vault-nav a,
+  .vault-nav-button {
+    justify-content: flex-start;
+    width: 100%;
+    min-height: 2.75rem;
+    padding: .85rem 1.25rem;
+    border-bottom: .5px solid var(--vault-border);
+    text-align: left;
+  }
+
+  .vault-page {
+    padding: 1.25rem 1rem 5rem;
   }
 
   .vault-toolbar {
@@ -631,6 +694,12 @@ small.text-muted {
   }
 
   .vault-search {
+    width: 100%;
+  }
+
+  .vault-search > .p-inputtext,
+  .vault-search > .p-select,
+  .vault-search > .p-button {
     width: 100%;
   }
 

--- a/src/passwordapp.ui/tests/unit/backup-settings-api.spec.js
+++ b/src/passwordapp.ui/tests/unit/backup-settings-api.spec.js
@@ -4,6 +4,7 @@ import {
   normalizeBackupSettings,
   getBackupSettings,
   putBackupSettings,
+  runBackupNow,
 } from '@/components/api/BackupSettings.Api.js';
 
 describe('backup settings API helper', () => {
@@ -67,5 +68,18 @@ describe('backup settings API helper', () => {
         RetentionCount: 20,
       },
     }]);
+  });
+
+  it('POSTs run-now backup requests', async () => {
+    const sent = [];
+    const http = {
+      async post(url) {
+        sent.push(url);
+        return { data: { LastStatus: 'Backed up 2 document(s).' } };
+      },
+    };
+
+    await expect(runBackupNow(http)).resolves.toMatchObject({ lastStatus: 'Backed up 2 document(s).' });
+    expect(sent).toEqual(['/api/backup-settings/run-now']);
   });
 });


### PR DESCRIPTION
## Summary
- move mobile/PWA navigation behind a hamburger menu and render accounts as stacked mobile cards
- add a manual Run Now trigger for encrypted vault backups
- wire Settings to POST /api/backup-settings/run-now with loading/error feedback

## Why
PR #29 was merged before these follow-up commits were included, so the deployed main build does not yet contain the PWA layout or Run Now button.

## Validation
- npm.cmd --prefix src\\passwordapp.ui run lint
- npm.cmd --prefix src\\passwordapp.ui run test:unit
- npm.cmd --prefix src\\passwordapp.ui run build
- dotnet test src\\passwordapp.api.tests\\passwordapp.api.tests.csproj --nologo
- dotnet build src\\passwordapp.api\\PasswordService.csproj -c Release --nologo