### PR TITLE
Cache accounts with Pinia

### DIFF
--- a/src/passwordapp.ui/package.json
+++ b/src/passwordapp.ui/package.json
@@ -21,6 +21,7 @@
     "bootstrap": "^5.3.8",
     "module": "^1.2.5",
     "moment": "^2.30.1",
+    "pinia": "^3.0.4",
     "primeicons": "^7.0.0",
     "primevue": "^4.5.5",
     "register-service-worker": "^1.7.2",

--- a/src/passwordapp.ui/src/components/create/create.js
+++ b/src/passwordapp.ui/src/components/create/create.js
@@ -3,6 +3,7 @@ import Authentication from '@/components/azuread/AzureAD.Authentication.js';
 import PasswordGenerator from '@/components/generator/generator.vue';
 import PasswordStrength from '@/components/strength/strength-meter.vue';
 import { parseTags, formatTags } from '@/components/utils/tags.js';
+import { useAccountsStore } from '@/stores/accounts.store.js';
 
 export default {
   name: 'Create',
@@ -20,6 +21,7 @@ export default {
   data() {
     return {
       formData: PasswordService.newPassword(),
+      accountsStore: useAccountsStore(),
       alertModalTitle: '',
       alertModalContent: '',
       isSuccessfully: false,
@@ -45,7 +47,7 @@ export default {
     },
     createNewAccount() {
       this.formData.createdBy = this.formData.lastModifiedBy = Authentication.getUserProfile(); 
-      PasswordService.create(this.formData).then(() => {
+      this.accountsStore.createAccount(this.formData).then(() => {
         this.isSuccessfully = true;
         this.alertModalTitle = 'Successfully';
         this.alertModalContent = 'Successfully created Account / Password';

--- a/src/passwordapp.ui/src/components/home/home.js
+++ b/src/passwordapp.ui/src/components/home/home.js
@@ -5,6 +5,7 @@ import { loadSettings } from '@/components/settings/settings.store.js';
 import { copyWithAutoClear } from '@/components/utils/clipboard.js';
 import { parseTags, collectTags, hasTag } from '@/components/utils/tags.js';
 import { isStale, ageLabel } from '@/components/utils/age.js';
+import { useAccountsStore } from '@/stores/accounts.store.js';
 
 export default {
   name: 'PasswordList',
@@ -14,6 +15,9 @@ export default {
     },
     allTags() {
       return collectTags(this.passwords);
+    },
+    passwords() {
+      return this.accountsStore.accounts;
     },
     tagChoices() {
       return [{ label: 'All tags', value: null }]
@@ -47,7 +51,7 @@ export default {
   data() {
     const settings = loadSettings(Authentication.getUserProfile());
     return {
-      passwords:    [],
+      accountsStore: useAccountsStore(),
       perPage:      settings.list.perPage,
       mobileFirst:  0,
       filter:       '',
@@ -149,27 +153,14 @@ export default {
       this.showDeleteModal = true;
     },
     fetchPasswords() {
-      this.apiError = '';
-      PasswordService.getAll()
-      .then((response) => {
-        this.passwords = response.data;
-      })
-      .catch((error) => {
-        this.passwords = [];
-        this.apiError = this.describeApiError(error, 'Unable to load accounts');
-      });
-    },
-    describeApiError(error, fallback) {
-      if (error.response) {
-        const detail = typeof error.response.data === 'string'
-          ? error.response.data
-          : error.response.data?.error || error.response.statusText;
-        return `${fallback}: ${error.response.status}${detail ? ` - ${detail}` : ''}`;
-      }
-      if (error.request) {
-        return `${fallback}: API request failed before a response was received. Check CORS, network access, and the configured API URL.`;
-      }
-      return `${fallback}: ${error.message || error}`;
+      this.apiError = this.accountsStore.error;
+      this.accountsStore.fetchAccounts()
+        .then(() => {
+          this.apiError = '';
+        })
+        .catch(() => {
+          this.apiError = this.accountsStore.error;
+        });
     },
     formatDate(date) {
       if (date) {
@@ -225,10 +216,9 @@ export default {
     },
     onDeleteConfirm() {
       this.showDeleteModal = false;
-      PasswordService.delete(this.selectedPasswordId)
+      this.accountsStore.deleteAccount(this.selectedPasswordId)
       .then(() => {
         this.showAlert('Successfully', 'Successfully deleted Account');
-        this.fetchPasswords();
       })
       .catch((error) => {
         this.showAlert('Error', error.response.data);

--- a/src/passwordapp.ui/src/components/transfer/transfer.js
+++ b/src/passwordapp.ui/src/components/transfer/transfer.js
@@ -1,6 +1,7 @@
 import PasswordService from '@/components/api/Password.Service.js';
 import Authentication from '@/components/azuread/AzureAD.Authentication.js';
 import { entriesToCsv, csvToEntries } from '@/components/transfer/csv.js';
+import { useAccountsStore } from '@/stores/accounts.store.js';
 
 export default {
   name: 'ImportExport',
@@ -20,6 +21,7 @@ export default {
       skipped: 0,
       imported: 0,
       failed: 0,
+      accountsStore: useAccountsStore(),
     };
   },
   computed: {
@@ -34,8 +36,7 @@ export default {
       this.exportError = '';
       this.exportMessage = '';
       try {
-        const listResponse = await PasswordService.getAll();
-        const accounts = Array.isArray(listResponse.data) ? listResponse.data : [];
+        const accounts = await this.accountsStore.fetchAccounts();
 
         // The list returns only encrypted blobs; fetch each entry for its
         // server-decrypted password.
@@ -130,7 +131,7 @@ export default {
           isDeleted: false,
         };
         try {
-          await PasswordService.create(payload);
+          await this.accountsStore.createAccount(payload);
           this.imported += 1;
         } catch {
           this.failed += 1;

--- a/src/passwordapp.ui/src/components/trash/trash.js
+++ b/src/passwordapp.ui/src/components/trash/trash.js
@@ -1,5 +1,6 @@
 import PasswordService from '@/components/api/Password.Service.js';
 import Moment from 'moment';
+import { useAccountsStore } from '@/stores/accounts.store.js';
 
 export default {
   name: 'RecycleBin',
@@ -10,6 +11,7 @@ export default {
       message: '',
       restoringId: null,
       entries: [],
+      accountsStore: useAccountsStore(),
     };
   },
   created() {
@@ -37,7 +39,7 @@ export default {
       this.error = '';
       this.message = '';
       try {
-        await PasswordService.restore(row.id);
+        await this.accountsStore.restoreAccount(row.id);
         this.entries = this.entries.filter(e => e.id !== row.id);
         this.message = `Restored "${row.accountName || row.siteName}" to the vault.`;
       } catch (err) {

--- a/src/passwordapp.ui/src/components/update/update.js
+++ b/src/passwordapp.ui/src/components/update/update.js
@@ -3,6 +3,7 @@ import Authentication from '@/components/azuread/AzureAD.Authentication.js';
 import PasswordGenerator from '@/components/generator/generator.vue';
 import PasswordStrength from '@/components/strength/strength-meter.vue';
 import { parseTags, formatTags } from '@/components/utils/tags.js';
+import { useAccountsStore } from '@/stores/accounts.store.js';
 
 export default {
   name: 'Update',
@@ -20,6 +21,7 @@ export default {
   data() {
     return {
       formData:           PasswordService.newPassword(),
+      accountsStore:      useAccountsStore(),
       id:                 '',
       alertModalTitle:    '',
       alertModalContent:  '',
@@ -40,7 +42,7 @@ export default {
     },
     updatePassword() {
       this.formData.lastModifiedBy = Authentication.getUserProfile();
-      PasswordService.update(this.id, this.formData)
+      this.accountsStore.updateAccount(this.id, this.formData)
       .then(() => {
         this.isSuccessfully = true;
         this.alertModalTitle = 'Successfully';

--- a/src/passwordapp.ui/src/css/main.css
+++ b/src/passwordapp.ui/src/css/main.css
@@ -426,8 +426,10 @@ body {
   min-height: 2.5rem;
 }
 
-.vault-select.p-select {
-  width: 9rem;
+.vault-select.p-select,
+.vault-select.p-inputtext {
+  width: 14.5rem;
+  max-width: 100%;
 }
 
 .p-inputtext::placeholder {

--- a/src/passwordapp.ui/src/main.js
+++ b/src/passwordapp.ui/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 
@@ -78,6 +79,7 @@ let requiresAppInsights = process.env.VUE_APP_REQUIRES_APP_INSIGHTS == 'true' ? 
   }
 
   const app = createApp(App);
+  app.use(createPinia());
   app.use(router);
   app.use(PrimeVue, {
     theme: {

--- a/src/passwordapp.ui/src/stores/accounts.store.js
+++ b/src/passwordapp.ui/src/stores/accounts.store.js
@@ -1,0 +1,113 @@
+import { defineStore } from 'pinia';
+import PasswordService from '@/components/api/Password.Service.js';
+
+const STALE_AFTER_MS = 5 * 60 * 1000;
+
+export const useAccountsStore = defineStore('accounts', {
+  state: () => ({
+    accounts: [],
+    loading: false,
+    error: '',
+    loadedAt: 0,
+    pendingFetch: null,
+  }),
+  getters: {
+    isLoaded: (state) => state.loadedAt > 0,
+    isStale: (state) => !state.loadedAt || Date.now() - state.loadedAt > STALE_AFTER_MS,
+  },
+  actions: {
+    async fetchAccounts({ force = false } = {}) {
+      if (!force && this.isLoaded && !this.isStale) {
+        return this.accounts;
+      }
+
+      if (this.pendingFetch) {
+        return this.pendingFetch;
+      }
+
+      this.loading = true;
+      this.error = '';
+      this.pendingFetch = PasswordService.getAll()
+        .then((response) => {
+          this.accounts = Array.isArray(response.data) ? response.data : [];
+          this.loadedAt = Date.now();
+          return this.accounts;
+        })
+        .catch((err) => {
+          this.accounts = [];
+          this.loadedAt = 0;
+          this.error = this.describeApiError(err, 'Unable to load accounts');
+          throw err;
+        })
+        .finally(() => {
+          this.loading = false;
+          this.pendingFetch = null;
+        });
+
+      return this.pendingFetch;
+    },
+    async refreshAccounts() {
+      return this.fetchAccounts({ force: true });
+    },
+    invalidateAccounts() {
+      this.loadedAt = 0;
+    },
+    removeAccount(id) {
+      this.accounts = this.accounts.filter(account => account.id !== id);
+      if (this.isLoaded) {
+        this.loadedAt = Date.now();
+      }
+    },
+    upsertAccount(account) {
+      if (!account || !account.id) {
+        this.invalidateAccounts();
+        return;
+      }
+
+      if (!this.isLoaded) {
+        this.invalidateAccounts();
+        return;
+      }
+
+      const index = this.accounts.findIndex(existing => existing.id === account.id);
+      if (index >= 0) {
+        this.accounts.splice(index, 1, account);
+      } else {
+        this.accounts.push(account);
+      }
+      this.loadedAt = Date.now();
+    },
+    async createAccount(payload) {
+      const response = await PasswordService.create(payload);
+      this.upsertAccount(response.data);
+      return response;
+    },
+    async updateAccount(id, payload) {
+      const response = await PasswordService.update(id, payload);
+      this.upsertAccount(response.data);
+      return response;
+    },
+    async deleteAccount(id) {
+      const response = await PasswordService.delete(id);
+      this.removeAccount(id);
+      return response;
+    },
+    async restoreAccount(id) {
+      const response = await PasswordService.restore(id);
+      this.invalidateAccounts();
+      return response;
+    },
+    describeApiError(error, fallback) {
+      if (error.response) {
+        const detail = typeof error.response.data === 'string'
+          ? error.response.data
+          : error.response.data?.error || error.response.statusText;
+        return `${fallback}: ${error.response.status}${detail ? ` - ${detail}` : ''}`;
+      }
+      if (error.request) {
+        return `${fallback}: API request failed before a response was received. Check CORS, network access, and the configured API URL.`;
+      }
+      return `${fallback}: ${error.message || error}`;
+    },
+  },
+});

--- a/src/passwordapp.ui/tests/unit/accounts-store.spec.js
+++ b/src/passwordapp.ui/tests/unit/accounts-store.spec.js
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useAccountsStore } from '@/stores/accounts.store.js';
+import PasswordService from '@/components/api/Password.Service.js';
+
+vi.mock('@/components/api/Password.Service.js', () => ({
+  default: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    restore: vi.fn(),
+  },
+}));
+
+describe('accounts.store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('caches account list fetches until forced or stale', async () => {
+    PasswordService.getAll.mockResolvedValue({ data: [{ id: 'one', accountName: 'alice' }] });
+    const store = useAccountsStore();
+
+    await expect(store.fetchAccounts()).resolves.toEqual([{ id: 'one', accountName: 'alice' }]);
+    await expect(store.fetchAccounts()).resolves.toEqual([{ id: 'one', accountName: 'alice' }]);
+
+    expect(PasswordService.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares an in-flight fetch between callers', async () => {
+    let resolveFetch;
+    PasswordService.getAll.mockReturnValue(new Promise(resolve => { resolveFetch = resolve; }));
+    const store = useAccountsStore();
+
+    const first = store.fetchAccounts();
+    const second = store.fetchAccounts();
+    resolveFetch({ data: [{ id: 'one' }] });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([[{ id: 'one' }], [{ id: 'one' }]]);
+    expect(PasswordService.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates cached rows after delete', async () => {
+    const store = useAccountsStore();
+    store.accounts = [{ id: 'one' }, { id: 'two' }];
+    store.loadedAt = Date.now();
+    PasswordService.delete.mockResolvedValue({ data: {} });
+
+    await store.deleteAccount('one');
+
+    expect(store.accounts).toEqual([{ id: 'two' }]);
+  });
+
+  it('invalidates when create returns no account body', async () => {
+    const store = useAccountsStore();
+    store.accounts = [{ id: 'one' }];
+    store.loadedAt = Date.now();
+    PasswordService.create.mockResolvedValue({ data: null });
+
+    await store.createAccount({ accountName: 'new' });
+
+    expect(store.loadedAt).toBe(0);
+  });
+
+  it('does not treat a single created account as a loaded full list', async () => {
+    const store = useAccountsStore();
+    PasswordService.create.mockResolvedValue({ data: { id: 'new', accountName: 'new' } });
+
+    await store.createAccount({ accountName: 'new' });
+
+    expect(store.accounts).toEqual([]);
+    expect(store.loadedAt).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Pinia and a shared accounts store that caches the account list across panel navigation
- wire account create/update/delete/restore/import/export paths to update or invalidate the shared cache
- keep backup schedule controls at a consistent width in Settings

## Validation
- npm.cmd --prefix src\\passwordapp.ui run lint
- npm.cmd --prefix src\\passwordapp.ui run test:unit
- npm.cmd --prefix src\\passwordapp.ui run build