### PR TITLE
Fix backup function indexing

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -36,7 +36,7 @@ The main resource group hosts the running vault:
 | **UI hosting** | `azurerm_static_web_app` (+ optional `..._custom_domain`) | Vue 3 SPA deployed by GitHub Actions via the SWA CLI. Custom domain gated by `add_custom_domain`. |
 
 ## Scheduled encrypted backups
-The .NET API Function App owns scheduled vault backups. A timer trigger (`BACKUP_TIMER_SCHEDULE`, default every 15 minutes) checks the schedule saved from the Settings page, exports the encrypted password documents as-is, writes `passwords.json` and `manifest.json` into a zip archive, and uploads it to the private `vault-backups` storage container. The backup process does not decrypt password values.
+The .NET API Function App owns scheduled vault backups. A timer trigger runs every 15 minutes, checks the schedule saved from the Settings page, exports the encrypted password documents as-is, writes `passwords.json` and `manifest.json` into a zip archive, and uploads it to the private `vault-backups` storage container. The backup process does not decrypt password values.
 
 ## Maintenance resource group _(optional)_
 Created when `deploy_maintenance_infrastructure = true` (`infrastructure/maintenance/`): its own resource group, storage account + `app` container, Linux service plan, **Python Function App** (keep-alive + legacy backup), a user-assigned identity and the matching storage role assignments. The API-hosted scheduled encrypted backup feature is intended to replace this optional project after rollout.

--- a/infrastructure/functions.tf
+++ b/infrastructure/functions.tf
@@ -63,7 +63,6 @@ resource "azurerm_function_app_flex_consumption" "this" {
     AAD_ALLOWED_OIDS                      = var.aad_allowed_oids
     BACKUP_STORAGE_ACCOUNT_NAME           = azurerm_storage_account.this.name
     BACKUP_STORAGE_CONTAINER_NAME         = azurerm_storage_container.vault_backups.name
-    BACKUP_TIMER_SCHEDULE                 = "0 */15 * * * *"
     APPLICATIONINSIGHTS_CONNECTION_STRING = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.appinsights_connection_string.id})"
     APPINSIGHTS_INSTRUMENTATIONKEY        = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.appinsights_key.id})"
   }

--- a/src/passwordapp.api/Functions/RunScheduledVaultBackup.cs
+++ b/src/passwordapp.api/Functions/RunScheduledVaultBackup.cs
@@ -9,12 +9,12 @@ namespace PasswordService.API
                 "%COSMOS_KEY_COLLECTION_NAME%",
                 PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
                 Connection = "COSMOSDB")]
-            public BackupSettingsRecord? Settings { get; set; }
+            public BackupSettingsRecord? SavedSettings { get; set; }
         }
 
         [Function(nameof(RunScheduledVaultBackup))]
         public async Task<RunScheduledVaultBackupOutput> RunScheduledVaultBackup(
-            [TimerTrigger("%BACKUP_TIMER_SCHEDULE%")] TimerInfo timer,
+            [TimerTrigger("0 */15 * * * *")] TimerInfo timer,
             [CosmosDBInput(
                 "%COSMOS_DATABASE_NAME%",
                 "%COSMOS_COLLECTION_NAME%",
@@ -43,7 +43,7 @@ namespace PasswordService.API
                 settings.LastStatus = "Invalid settings";
                 settings.LastError = validationError;
                 _logger.LogWarning("Scheduled vault backup skipped: {Reason}", validationError);
-                return new RunScheduledVaultBackupOutput { Settings = settings };
+                return new RunScheduledVaultBackupOutput { SavedSettings = settings };
             }
 
             if (!VaultBackupScheduler.ShouldRun(settings, now))
@@ -63,7 +63,7 @@ namespace PasswordService.API
                 _logger.LogError(ex, "Scheduled vault backup failed.");
             }
 
-            return new RunScheduledVaultBackupOutput { Settings = settings };
+            return new RunScheduledVaultBackupOutput { SavedSettings = settings };
         }
 
         private async Task CreateVaultBackupAsync(

--- a/src/passwordapp.api/Functions/RunVaultBackupNow.cs
+++ b/src/passwordapp.api/Functions/RunVaultBackupNow.cs
@@ -11,7 +11,7 @@ namespace PasswordService.API
                 "%COSMOS_KEY_COLLECTION_NAME%",
                 PartitionKey = "%COSMOS_KEY_PARTITION_KEY%",
                 Connection = "COSMOSDB")]
-            public BackupSettingsRecord? Settings { get; set; }
+            public BackupSettingsRecord? SavedSettings { get; set; }
 
             [HttpResult]
             public HttpResponseData Response { get; set; } = default!;
@@ -46,7 +46,7 @@ namespace PasswordService.API
                 settings.LastError = validationError;
                 return new RunVaultBackupNowOutput
                 {
-                    Settings = settings,
+                    SavedSettings = settings,
                     Response = await JsonResponse(req, HttpStatusCode.BadRequest, settings),
                 };
             }
@@ -56,7 +56,7 @@ namespace PasswordService.API
                 await CreateVaultBackupAsync(passwordCollection, settings, now, "Manual vault backup");
                 return new RunVaultBackupNowOutput
                 {
-                    Settings = settings,
+                    SavedSettings = settings,
                     Response = await JsonResponse(req, HttpStatusCode.OK, settings),
                 };
             }
@@ -67,7 +67,7 @@ namespace PasswordService.API
                 _logger.LogError(ex, "Manual vault backup failed.");
                 return new RunVaultBackupNowOutput
                 {
-                    Settings = settings,
+                    SavedSettings = settings,
                     Response = await JsonResponse(req, HttpStatusCode.InternalServerError, settings),
                 };
             }


### PR DESCRIPTION
Fixes backup function indexing by avoiding the Settings/settings binding-name collision and using a literal 15-minute timer schedule. Validation: API tests/build/publish metadata inspection and Terraform fmt/validate.