### PR TITLE
Fix classic theme PWA support

### DIFF
--- a/src/passwordapp.ui/src/App.vue
+++ b/src/passwordapp.ui/src/App.vue
@@ -17,11 +17,11 @@
       <nav id="vault-navigation" class="vault-nav" :class="{ 'is-open': navOpen }" aria-label="Vault navigation" @click="closeNav">
         <template v-if="vaultUnlocked">
           <router-link class="classic-only" :to="{ name: 'Create' }">New Account</router-link>
-          <router-link :to="{ name: 'Home' }"><i class="pi pi-id-card"></i> Accounts</router-link>
+          <router-link class="non-classic-only" :to="{ name: 'Home' }"><i class="pi pi-id-card"></i> Accounts</router-link>
           <router-link :to="{ name: 'Settings' }"><i class="pi pi-cog"></i> Settings</router-link>
-          <router-link :to="{ name: 'Trash' }"><i class="pi pi-trash"></i> Recycle bin</router-link>
-          <router-link :to="{ name: 'Audit' }"><i class="pi pi-shield"></i> Audit</router-link>
-          <router-link :to="{ name: 'Transfer' }"><i class="pi pi-sort-alt"></i> Import / Export</router-link>
+          <router-link class="non-classic-only" :to="{ name: 'Trash' }"><i class="pi pi-trash"></i> Recycle bin</router-link>
+          <router-link class="non-classic-only" :to="{ name: 'Audit' }"><i class="pi pi-shield"></i> Audit</router-link>
+          <router-link class="non-classic-only" :to="{ name: 'Transfer' }"><i class="pi pi-sort-alt"></i> Import / Export</router-link>
         </template>
         <router-link v-if="vaultUnlocked" class="vault-nav-button non-classic-only" :to="{ name: 'Create' }"><i class="pi pi-plus"></i> New</router-link>
         <button class="vault-nav-button" type="button" @click="logOut">Sign out</button>

--- a/src/passwordapp.ui/src/components/pwa/install.js
+++ b/src/passwordapp.ui/src/components/pwa/install.js
@@ -1,0 +1,23 @@
+export function isStandalone(matchMedia, navigatorLike) {
+  const media = matchMedia || (typeof window !== 'undefined' ? window.matchMedia : null);
+  const nav = navigatorLike || (typeof navigator !== 'undefined' ? navigator : null);
+  return Boolean(
+    (media && media('(display-mode: standalone)').matches) ||
+    (nav && nav.standalone)
+  );
+}
+
+export function shouldShowInstallPrompt(event, standalone) {
+  return Boolean(event && !standalone);
+}
+
+export async function promptInstall(event) {
+  if (!event || typeof event.prompt !== 'function') {
+    return null;
+  }
+  event.prompt();
+  if (!event.userChoice || typeof event.userChoice.then !== 'function') {
+    return null;
+  }
+  return event.userChoice;
+}

--- a/src/passwordapp.ui/src/components/pwa/update-prompt.vue
+++ b/src/passwordapp.ui/src/components/pwa/update-prompt.vue
@@ -1,13 +1,21 @@
 <template>
-  <div v-if="visible" class="pwa-update-banner" role="status" aria-live="polite">
-    <span class="pwa-update-text">A new version of Password Vault is available.</span>
-    <Button label="Refresh" size="small" severity="contrast" @click="refresh" />
+  <div v-if="visible || installVisible" class="pwa-support-banner" role="status" aria-live="polite">
+    <div v-if="installVisible" class="pwa-support-item">
+      <span class="pwa-support-text">Install Password Vault for faster access and offline app support.</span>
+      <Button label="Install" size="small" severity="contrast" @click="install" />
+      <Button label="Not now" size="small" severity="secondary" text @click="dismissInstall" />
+    </div>
+    <div v-if="visible" class="pwa-support-item">
+      <span class="pwa-support-text">A new version of Password Vault is available.</span>
+      <Button label="Refresh" size="small" severity="contrast" @click="refresh" />
+    </div>
   </div>
 </template>
 
 <script>
 import { ref, onMounted, onUnmounted } from 'vue';
 import { skipWaiting, reloadOnControllerChange } from './sw-update.js';
+import { isStandalone, promptInstall, shouldShowInstallPrompt } from './install.js';
 
 // Listens for the 'swUpdated' event emitted by registerServiceWorker.js when a
 // new service worker has been installed and is waiting. Shows a non-intrusive
@@ -17,12 +25,38 @@ export default {
   name: 'UpdatePrompt',
   setup() {
     const visible = ref(false);
+    const installVisible = ref(false);
     let registration = null;
+    let installEvent = null;
     let cleanup = null;
 
     const onUpdated = (event) => {
       registration = event.detail;
       visible.value = true;
+    };
+
+    const onBeforeInstallPrompt = (event) => {
+      if (event && typeof event.preventDefault === 'function') {
+        event.preventDefault();
+      }
+      installEvent = event;
+      installVisible.value = shouldShowInstallPrompt(event, isStandalone());
+    };
+
+    const onAppInstalled = () => {
+      installEvent = null;
+      installVisible.value = false;
+    };
+
+    const dismissInstall = () => {
+      installVisible.value = false;
+    };
+
+    const install = () => {
+      const event = installEvent;
+      installVisible.value = false;
+      installEvent = null;
+      promptInstall(event);
     };
 
     const refresh = () => {
@@ -38,31 +72,34 @@ export default {
       window.location.reload();
     };
 
-    onMounted(() => window.addEventListener('swUpdated', onUpdated));
+    onMounted(() => {
+      window.addEventListener('swUpdated', onUpdated);
+      window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+      window.addEventListener('appinstalled', onAppInstalled);
+    });
     onUnmounted(() => {
       window.removeEventListener('swUpdated', onUpdated);
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', onAppInstalled);
       if (cleanup) {
         cleanup();
       }
     });
 
-    return { visible, refresh };
+    return { visible, installVisible, dismissInstall, install, refresh };
   },
 };
 </script>
 
 <style scoped>
-.pwa-update-banner {
+.pwa-support-banner {
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
   z-index: 1080;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
+  display: grid;
+  gap: .75rem;
   padding: 0.75rem 1rem;
   border-top: .5px solid var(--vault-border);
   background: var(--vault-bg);
@@ -70,7 +107,15 @@ export default {
   box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.28);
 }
 
-.pwa-update-text {
+.pwa-support-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: .75rem;
+}
+
+.pwa-support-text {
   color: var(--vault-muted);
   font-size: .8125rem;
 }

--- a/src/passwordapp.ui/tests/unit/pwa-install.spec.js
+++ b/src/passwordapp.ui/tests/unit/pwa-install.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isStandalone, shouldShowInstallPrompt, promptInstall } from '@/components/pwa/install.js';
+
+describe('isStandalone', () => {
+  it('detects display-mode standalone', () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: true });
+    expect(isStandalone(matchMedia, {})).toBe(true);
+    expect(matchMedia).toHaveBeenCalledWith('(display-mode: standalone)');
+  });
+
+  it('detects iOS standalone mode', () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: false });
+    expect(isStandalone(matchMedia, { standalone: true })).toBe(true);
+  });
+
+  it('returns false for a regular browser tab', () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: false });
+    expect(isStandalone(matchMedia, { standalone: false })).toBe(false);
+  });
+});
+
+describe('shouldShowInstallPrompt', () => {
+  it('shows the install prompt only when installable and not already standalone', () => {
+    expect(shouldShowInstallPrompt({ prompt: vi.fn() }, false)).toBe(true);
+    expect(shouldShowInstallPrompt({ prompt: vi.fn() }, true)).toBe(false);
+    expect(shouldShowInstallPrompt(null, false)).toBe(false);
+  });
+});
+
+describe('promptInstall', () => {
+  it('calls the deferred prompt and returns the browser choice', async () => {
+    const choice = Promise.resolve({ outcome: 'accepted' });
+    const event = { prompt: vi.fn(), userChoice: choice };
+    await expect(promptInstall(event)).resolves.toEqual({ outcome: 'accepted' });
+    expect(event.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fail when the browser event is unavailable', async () => {
+    await expect(promptInstall(null)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Show the classic Settings navigation link while keeping richer vault links hidden in classic mode. Add a theme-independent PWA install prompt alongside the service worker update prompt.