### PR TITLE
Fix classic PWA support and mobile vault issues

### DIFF
--- a/src/passwordapp.ui/src/components/home/home.css
+++ b/src/passwordapp.ui/src/components/home/home.css
@@ -153,12 +153,7 @@
   }
 
   body.theme-classic .vault-mobile-account-actions .p-button + .p-button::before {
-    content: '|';
-    position: absolute;
-    left: -.55rem;
-    color: #000;
-    font-size: 1.25rem;
-    font-weight: 400;
+    content: none;
   }
 
   body.theme-classic .vault-mobile-details {

--- a/src/passwordapp.ui/src/components/home/home.js
+++ b/src/passwordapp.ui/src/components/home/home.js
@@ -70,6 +70,9 @@ export default {
       showDeleteModal:    false,
       showAlertModal:     false,
       showHistoryModal:   false,
+      showClipboardRetryModal: false,
+      clipboardRetryText: '',
+      clipboardRetryError: '',
       apiError:           '',
       accountRefreshTimer: null,
     };
@@ -215,23 +218,49 @@ export default {
       });
     },
     copyText(text) {
-      copyWithAutoClear(text, this.clipboardClearSeconds)
+      this.writeSecretToClipboard(text);
+    },
+    writeSecretToClipboard(text) {
+      return copyWithAutoClear(text, this.clipboardClearSeconds)
         .then(() => {
           this.showAlert('Success. . .', this.copySuccessMessage());
         })
         .catch(err => {
-          this.showAlert('Error. . .', "Copy failed with error: " + err);
+          this.requestClipboardRetry(text, err);
         });
     },
     copyPassword(passwordId) {
       PasswordService.get(passwordId)
-        .then(response => copyWithAutoClear(response.data.currentPassword, this.clipboardClearSeconds))
+        .then(response => this.writeSecretToClipboard(response.data.currentPassword))
+        .catch(err => {
+          this.requestClipboardRetry('', err);
+        });
+    },
+    requestClipboardRetry(text, error) {
+      this.clipboardRetryText = text || '';
+      this.clipboardRetryError = error ? String(error) : '';
+      this.showClipboardRetryModal = Boolean(text);
+      if (!text) {
+        this.showAlert('Error. . .', "Copy failed with error: " + error);
+      }
+    },
+    retryClipboardCopy() {
+      const text = this.clipboardRetryText;
+      this.clipboardRetryError = '';
+      copyWithAutoClear(text, this.clipboardClearSeconds)
         .then(() => {
+          this.showClipboardRetryModal = false;
+          this.clipboardRetryText = '';
           this.showAlert('Success. . .', this.copySuccessMessage());
         })
         .catch(err => {
-          this.showAlert('Error. . .', "Copy failed with error: " + err);
+          this.clipboardRetryError = String(err);
         });
+    },
+    cancelClipboardRetry() {
+      this.showClipboardRetryModal = false;
+      this.clipboardRetryText = '';
+      this.clipboardRetryError = '';
     },
     copySuccessMessage() {
       const secs = Number(this.clipboardClearSeconds);

--- a/src/passwordapp.ui/src/components/home/home.vue
+++ b/src/passwordapp.ui/src/components/home/home.vue
@@ -177,6 +177,19 @@
       </template>
     </Dialog>
 
+    <Dialog v-model:visible="showClipboardRetryModal" modal header="Copy Password" :style="{ width: '30rem' }" @hide="cancelClipboardRetry()">
+      <p class="my-4">
+        This device needs a direct tap before it allows clipboard access. Tap Copy now to finish copying the password.
+      </p>
+      <Message v-if="clipboardRetryError" severity="error" class="mb-3 py-2">
+        Copy failed with error: {{ clipboardRetryError }}
+      </Message>
+      <template #footer>
+        <Button label="Cancel" severity="secondary" @click="cancelClipboardRetry()" />
+        <Button label="Copy now" severity="success" @click.stop="retryClipboardCopy()" />
+      </template>
+    </Dialog>
+
     <Dialog v-model:visible="showHistoryModal" modal header="Password History" :style="{ width: '50rem' }">
       <p v-if="history.length === 0" class="my-4">No password history is available for this account.</p>
       <DataTable v-else :value="history" stripedRows size="small" responsiveLayout="stack">

--- a/src/passwordapp.ui/src/components/utils/clipboard.js
+++ b/src/passwordapp.ui/src/components/utils/clipboard.js
@@ -7,18 +7,59 @@
 
 let pendingClear = null;
 
+function legacyCopyText(text, documentRef) {
+  const doc = documentRef || (typeof document !== 'undefined' ? document : undefined);
+  if (!doc || !doc.body || typeof doc.createElement !== 'function' || typeof doc.execCommand !== 'function') {
+    return Promise.reject(new Error('Clipboard API unavailable'));
+  }
+
+  const textarea = doc.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '0';
+  textarea.style.left = '-9999px';
+  textarea.style.opacity = '0';
+  doc.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  let copied = false;
+  try {
+    copied = doc.execCommand('copy');
+  } finally {
+    doc.body.removeChild(textarea);
+  }
+  return copied
+    ? Promise.resolve()
+    : Promise.reject(new Error('Clipboard copy failed'));
+}
+
+export function writeClipboardText(text, deps = {}) {
+  const {
+    clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined,
+    documentRef = typeof document !== 'undefined' ? document : undefined,
+  } = deps;
+
+  if (clipboard && typeof clipboard.writeText === 'function') {
+    return Promise.resolve(clipboard.writeText(text))
+      .catch(primaryError => legacyCopyText(text, documentRef)
+        .catch(() => { throw primaryError; }));
+  }
+
+  return legacyCopyText(text, documentRef);
+}
+
 export function copyWithAutoClear(text, seconds, deps = {}) {
   const {
     clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined,
+    documentRef = typeof document !== 'undefined' ? document : undefined,
     setTimer = (fn, ms) => setTimeout(fn, ms),
     clearTimer = (id) => clearTimeout(id),
   } = deps;
 
-  if (!clipboard || typeof clipboard.writeText !== 'function') {
-    return Promise.reject(new Error('Clipboard API unavailable'));
-  }
-
-  return clipboard.writeText(text).then(() => {
+  return writeClipboardText(text, { clipboard, documentRef }).then(() => {
     if (pendingClear !== null) {
       clearTimer(pendingClear);
       pendingClear = null;
@@ -29,7 +70,7 @@ export function copyWithAutoClear(text, seconds, deps = {}) {
       pendingClear = setTimer(() => {
         pendingClear = null;
         // Best-effort: ignore failures (e.g. document lost focus).
-        Promise.resolve(clipboard.writeText('')).catch(() => {});
+        writeClipboardText('', { clipboard, documentRef }).catch(() => {});
       }, secs * 1000);
     }
 

--- a/src/passwordapp.ui/src/css/main.css
+++ b/src/passwordapp.ui/src/css/main.css
@@ -565,12 +565,39 @@ body.theme-classic .p-datatable .p-datatable-tbody > tr > td {
 }
 
 .vault-icon-button.p-button {
-  width: 1.875rem;
-  min-width: 1.875rem;
-  height: 1.875rem;
-  min-height: 1.875rem;
+  width: 2.75rem;
+  min-width: 2.75rem;
+  height: 2.75rem;
+  min-height: 2.75rem;
   padding: 0;
-  font-size: .875rem;
+  border-color: transparent !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: var(--vault-accent-strong) !important;
+  font-size: 1.125rem;
+}
+
+.vault-icon-button.p-button:hover,
+.vault-icon-button.p-button:focus-visible {
+  border-color: transparent !important;
+  background: transparent !important;
+  color: var(--vault-accent) !important;
+}
+
+.vault-icon-button.p-button-success {
+  color: var(--vault-success) !important;
+}
+
+.vault-icon-button.p-button-danger {
+  color: var(--vault-danger) !important;
+}
+
+.vault-icon-button.p-button-info {
+  color: var(--vault-info) !important;
+}
+
+.vault-icon-button.p-button-warn {
+  color: var(--vault-accent) !important;
 }
 
 .vault-action-row {
@@ -581,11 +608,7 @@ body.theme-classic .p-datatable .p-datatable-tbody > tr > td {
 }
 
 body.theme-classic .vault-icon-button.p-button {
-  width: 2.25rem;
-  min-width: 2.25rem;
-  height: 2.25rem;
-  min-height: 2.25rem;
-  border-radius: .25rem;
+  border-radius: 0;
 }
 
 .p-inputtext,

--- a/src/passwordapp.ui/tests/unit/clipboard.spec.js
+++ b/src/passwordapp.ui/tests/unit/clipboard.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { copyWithAutoClear, _resetPendingClear } from '@/components/utils/clipboard.js';
+import { copyWithAutoClear, writeClipboardText, _resetPendingClear } from '@/components/utils/clipboard.js';
 
 function fakeClipboard() {
   return {
@@ -10,6 +10,49 @@ function fakeClipboard() {
     },
   };
 }
+
+function fakeDocument(execResult = true) {
+  const element = {
+    value: '',
+    style: {},
+    setAttribute: vi.fn(),
+    focus: vi.fn(),
+    select: vi.fn(),
+    setSelectionRange: vi.fn(),
+  };
+  return {
+    element,
+    body: {
+      appendChild: vi.fn(),
+      removeChild: vi.fn(),
+    },
+    createElement: vi.fn(() => element),
+    execCommand: vi.fn(() => execResult),
+  };
+}
+
+describe('writeClipboardText', () => {
+  it('falls back to execCommand when clipboard.writeText is rejected', async () => {
+    const clipboard = { writeText: vi.fn(() => Promise.reject(new DOMException('NotAllowedError'))) };
+    const documentRef = fakeDocument();
+    await writeClipboardText('ios-secret', { clipboard, documentRef });
+    expect(documentRef.element.value).toBe('ios-secret');
+    expect(documentRef.execCommand).toHaveBeenCalledWith('copy');
+    expect(documentRef.body.removeChild).toHaveBeenCalledWith(documentRef.element);
+  });
+
+  it('uses the legacy copy path when the Clipboard API is unavailable', async () => {
+    const documentRef = fakeDocument();
+    await writeClipboardText('legacy-secret', { clipboard: undefined, documentRef });
+    expect(documentRef.element.value).toBe('legacy-secret');
+    expect(documentRef.execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('rejects when neither clipboard API nor legacy copy is available', async () => {
+    await expect(writeClipboardText('x', { clipboard: undefined, documentRef: undefined }))
+      .rejects.toThrow('Clipboard API unavailable');
+  });
+});
 
 describe('copyWithAutoClear', () => {
   beforeEach(() => {
@@ -50,7 +93,7 @@ describe('copyWithAutoClear', () => {
   });
 
   it('rejects when the clipboard API is unavailable', async () => {
-    await expect(copyWithAutoClear('x', 30, { clipboard: undefined }))
+    await expect(copyWithAutoClear('x', 30, { clipboard: undefined, documentRef: undefined }))
       .rejects.toThrow('Clipboard API unavailable');
   });
 });


### PR DESCRIPTION
## Summary
- restore classic nav to show New Account, Settings, and Sign out
- add a theme-independent PWA install/update support banner
- fix iOS clipboard copy by adding a legacy copy fallback and direct-tap retry dialog
- simplify vault action icons to icon-only touch targets without boxed backgrounds

Fixes #37
Fixes #38

## Validation
- npm run lint -- --quiet
- npx vitest run tests/unit/clipboard.spec.js tests/unit/pwa-install.spec.js tests/unit/sw-update.spec.js
- npm run build
- npm run build -- --mode development