### PR TITLE
Refine mobile toasts and theme layouts

### DIFF
--- a/src/passwordapp.ui/src/App.vue
+++ b/src/passwordapp.ui/src/App.vue
@@ -31,6 +31,7 @@
       <PasskeyVaultGate v-if="e2eeEnabled" />
       <router-view v-if="vaultUnlocked" />
     </main>
+    <Toast position="bottom-right" />
     <UpdatePrompt />
   </div> 
 </template>

--- a/src/passwordapp.ui/src/components/create/create.js
+++ b/src/passwordapp.ui/src/components/create/create.js
@@ -45,14 +45,22 @@ export default {
         this.$router.push({ name: 'Home' });
       }
     },
+    showSuccessToast(summary, detail) {
+      if (this.$toast && typeof this.$toast.add === 'function') {
+        this.$toast.add({
+          severity: 'success',
+          summary,
+          detail,
+          life: 3500,
+        });
+      }
+    },
     createNewAccount() {
       this.formData.createdBy = this.formData.lastModifiedBy = Authentication.getUserProfile(); 
       this.accountsStore.createAccount(this.formData).then(() => {
-        this.isSuccessfully = true;
-        this.alertModalTitle = 'Successfully';
-        this.alertModalContent = 'Successfully created Account / Password';
-        this.showAlertModal = true;
+        this.showSuccessToast('Account created', 'The account was added to the vault.');
         this.formData = PasswordService.newPassword();
+        this.$router.push({ name: 'Home' });
         
       }).catch((error) => {
         this.isSuccessfully = false;

--- a/src/passwordapp.ui/src/components/create/create.js
+++ b/src/passwordapp.ui/src/components/create/create.js
@@ -24,7 +24,6 @@ export default {
       accountsStore: useAccountsStore(),
       alertModalTitle: '',
       alertModalContent: '',
-      isSuccessfully: false,
       showAlertModal: false,
     };
   },
@@ -33,17 +32,7 @@ export default {
       this.formData.currentPassword = password;
     },
     onAlertOk() {
-
       this.showAlertModal = false;
-
-      this.onAlertModalOkClick();
-
-    },
-
-    onAlertModalOkClick() {
-      if (this.isSuccessfully) {
-        this.$router.push({ name: 'Home' });
-      }
     },
     showSuccessToast(summary, detail) {
       if (this.$toast && typeof this.$toast.add === 'function') {
@@ -61,9 +50,8 @@ export default {
         this.showSuccessToast('Account created', 'The account was added to the vault.');
         this.formData = PasswordService.newPassword();
         this.$router.push({ name: 'Home' });
-        
       }).catch((error) => {
-        this.isSuccessfully = false;
+      }).catch((error) => {
         this.alertModalTitle = 'Error';
         this.alertModalContent = "Got an error " + error.response.data;
         this.showAlertModal = true;

--- a/src/passwordapp.ui/src/components/home/home.css
+++ b/src/passwordapp.ui/src/components/home/home.css
@@ -51,6 +51,20 @@
   gap: .35rem;
 }
 
+.vault-mobile-actions-row {
+  grid-template-columns: 1fr;
+}
+
+.vault-mobile-actions-row .vault-mobile-account-label {
+  display: none;
+}
+
+.vault-mobile-actions-row .vault-mobile-account-actions {
+  grid-column: 1 / -1;
+  justify-content: space-evenly;
+  padding: .95rem .75rem;
+}
+
 .vault-mobile-details {
   display: grid;
   gap: .4rem;
@@ -104,7 +118,7 @@
   }
 
   body.theme-classic .vault-mobile-account-row {
-    grid-template-columns: 42% 58%;
+    grid-template-columns: 40% minmax(0, 60%);
     min-height: 3.5rem;
     border-bottom: 2px solid #dee2e6;
     background: #f5f5f5;
@@ -129,9 +143,19 @@
   }
 
   body.theme-classic .vault-mobile-account-value {
-    justify-content: center;
+    justify-content: flex-start;
+    min-width: 0;
     overflow: hidden;
-    text-align: center;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  body.theme-classic .vault-mobile-truncate {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -146,6 +170,18 @@
 
   body.theme-classic .vault-mobile-account-actions .vault-history-action {
     display: none;
+  }
+
+  body.theme-classic .vault-mobile-actions-row {
+    grid-template-columns: 40% minmax(0, 60%);
+  }
+
+  body.theme-classic .vault-mobile-actions-row .vault-mobile-account-label {
+    display: flex;
+  }
+
+  body.theme-classic .vault-mobile-actions-row .vault-mobile-account-actions {
+    grid-column: auto;
   }
 
   body.theme-classic .vault-mobile-account-actions .p-button {

--- a/src/passwordapp.ui/src/components/home/home.js
+++ b/src/passwordapp.ui/src/components/home/home.js
@@ -203,16 +203,19 @@ export default {
     },
     showCopyToast() {
       const message = this.copySuccessMessage();
+      this.showSuccessToast('Copied', message);
+    },
+    showSuccessToast(summary, detail) {
       if (this.$toast && typeof this.$toast.add === 'function') {
         this.$toast.add({
           severity: 'success',
-          summary: 'Copied',
-          detail: message,
+          summary,
+          detail,
           life: 3500,
         });
         return;
       }
-      this.showAlert('Success. . .', message);
+      this.showAlert('Success. . .', detail);
     },
     displayPassword(passwordId) {
       PasswordService.get(passwordId)
@@ -286,7 +289,7 @@ export default {
       this.showDeleteModal = false;
       this.accountsStore.deleteAccount(this.selectedPasswordId)
       .then(() => {
-        this.showAlert('Successfully', 'Successfully deleted Account');
+        this.showSuccessToast('Account deleted', 'The account was moved to the recycle bin.');
       })
       .catch((error) => {
         this.showAlert('Error', error.response.data);

--- a/src/passwordapp.ui/src/components/home/home.js
+++ b/src/passwordapp.ui/src/components/home/home.js
@@ -215,7 +215,6 @@ export default {
         });
         return;
       }
-      this.showAlert('Success. . .', detail);
     },
     displayPassword(passwordId) {
       PasswordService.get(passwordId)

--- a/src/passwordapp.ui/src/components/home/home.js
+++ b/src/passwordapp.ui/src/components/home/home.js
@@ -201,6 +201,19 @@ export default {
       this.alertModalContent = content;
       this.showAlertModal = true;
     },
+    showCopyToast() {
+      const message = this.copySuccessMessage();
+      if (this.$toast && typeof this.$toast.add === 'function') {
+        this.$toast.add({
+          severity: 'success',
+          summary: 'Copied',
+          detail: message,
+          life: 3500,
+        });
+        return;
+      }
+      this.showAlert('Success. . .', message);
+    },
     displayPassword(passwordId) {
       PasswordService.get(passwordId)
       .then((response) => {
@@ -223,7 +236,7 @@ export default {
     writeSecretToClipboard(text) {
       return copyWithAutoClear(text, this.clipboardClearSeconds)
         .then(() => {
-          this.showAlert('Success. . .', this.copySuccessMessage());
+          this.showCopyToast();
         })
         .catch(err => {
           this.requestClipboardRetry(text, err);
@@ -251,7 +264,7 @@ export default {
         .then(() => {
           this.showClipboardRetryModal = false;
           this.clipboardRetryText = '';
-          this.showAlert('Success. . .', this.copySuccessMessage());
+          this.showCopyToast();
         })
         .catch(err => {
           this.clipboardRetryError = String(err);

--- a/src/passwordapp.ui/src/components/home/home.vue
+++ b/src/passwordapp.ui/src/components/home/home.vue
@@ -106,7 +106,7 @@
         <div class="vault-mobile-account-row">
           <div class="vault-mobile-account-label">Account</div>
           <div class="vault-mobile-account-value">
-            <span class="text-lowercase">{{ password.accountName }}</span>
+            <span class="text-lowercase vault-mobile-truncate" :title="password.accountName">{{ password.accountName }}</span>
             <div v-if="tagsOf(password).length" class="mt-1">
               <Tag v-for="tag in tagsOf(password)" :key="tag" :value="tag" severity="secondary" class="me-1 mb-1" @click.stop="selectedTag = tag" style="cursor: pointer;" />
             </div>
@@ -114,20 +114,20 @@
         </div>
         <div class="vault-mobile-account-row">
           <div class="vault-mobile-account-label">Site</div>
-          <div class="vault-mobile-account-value text-lowercase">{{ password.siteName }}</div>
+          <div class="vault-mobile-account-value text-lowercase vault-mobile-truncate" :title="password.siteName">{{ password.siteName }}</div>
         </div>
         <div class="vault-mobile-account-row">
           <div class="vault-mobile-account-label">Last Modified</div>
-          <div class="vault-mobile-account-value">
-            <div>{{ formatDate(password.lastModifiedDate) }}</div>
+          <div class="vault-mobile-account-value vault-mobile-truncate" :title="`${formatDate(password.lastModifiedDate) || ''} ${isStaleRow(password) ? staleAgeOf(password) : ageOf(password)}`.trim()">
+            <div class="vault-mobile-truncate">{{ formatDate(password.lastModifiedDate) }}</div>
             <small
-              class="text-muted"
+              class="text-muted vault-mobile-truncate"
               :class="{ 'fst-italic': isStaleRow(password) }">
               {{ isStaleRow(password) ? staleAgeOf(password) : ageOf(password) }}
             </small>
           </div>
         </div>
-        <div class="vault-mobile-account-row">
+        <div class="vault-mobile-account-row vault-mobile-actions-row">
           <div class="vault-mobile-account-label">Edit/Remove</div>
           <div class="vault-mobile-account-actions vault-action-row">
             <Button class="vault-icon-button" size="small" severity="success" aria-label="Copy password" @click.stop="copyPassword(password.id)" v-tooltip.top="'Copy'"><font-awesome-icon icon="copy" /></Button>

--- a/src/passwordapp.ui/src/components/update/update.js
+++ b/src/passwordapp.ui/src/components/update/update.js
@@ -40,14 +40,22 @@ export default {
     onGenerated(password) {
       this.formData.currentPassword = password;
     },
+    showSuccessToast(summary, detail) {
+      if (this.$toast && typeof this.$toast.add === 'function') {
+        this.$toast.add({
+          severity: 'success',
+          summary,
+          detail,
+          life: 3500,
+        });
+      }
+    },
     updatePassword() {
       this.formData.lastModifiedBy = Authentication.getUserProfile();
       this.accountsStore.updateAccount(this.id, this.formData)
       .then(() => {
-        this.isSuccessfully = true;
-        this.alertModalTitle = 'Successfully';
-        this.alertModalContent = 'Successfully updated Account';
-        this.showAlertModal = true;
+        this.showSuccessToast('Account updated', 'The account changes were saved.');
+        this.$router.push({ name: 'Home' });
       })
       .catch((error) => {
         this.isSuccessfully = false;

--- a/src/passwordapp.ui/src/components/update/update.js
+++ b/src/passwordapp.ui/src/components/update/update.js
@@ -25,7 +25,6 @@ export default {
       id:                 '',
       alertModalTitle:    '',
       alertModalContent:  '',
-      isSuccessfully:     false,
       showAlertModal:     false,
     };
   },
@@ -58,24 +57,13 @@ export default {
         this.$router.push({ name: 'Home' });
       })
       .catch((error) => {
-        this.isSuccessfully = false;
-        this.alertModalTitle = 'Error';
-        this.alertModalContent = error.response.data;
-        this.showAlertModal = true;
+          this.alertModalTitle = 'Error';
+          this.alertModalContent = error.response.data;
+          this.showAlertModal = true;
       });
     },
     onAlertOk() {
-
       this.showAlertModal = false;
-
-      this.onAlertModalOkClick();
-
-    },
-
-    onAlertModalOkClick() {
-      if (this.isSuccessfully) {
-        this.$router.push({ name: 'Home' });
-      }
     },
   },
 };

--- a/src/passwordapp.ui/src/css/main.css
+++ b/src/passwordapp.ui/src/css/main.css
@@ -611,6 +611,37 @@ body.theme-classic .vault-icon-button.p-button {
   border-radius: 0;
 }
 
+.p-toast {
+  width: min(26rem, calc(100vw - 2rem));
+}
+
+.p-toast .p-toast-message {
+  border: .5px solid var(--vault-border);
+  border-radius: .875rem;
+  background: var(--vault-surface) !important;
+  color: var(--vault-text);
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, .32);
+}
+
+.p-toast .p-toast-message-content {
+  align-items: center;
+  padding: 1rem 1.125rem;
+}
+
+.p-toast .p-toast-summary {
+  color: var(--vault-text);
+  font-weight: 700;
+}
+
+.p-toast .p-toast-detail {
+  color: var(--vault-muted);
+  line-height: 1.45;
+}
+
+body.theme-classic .p-toast .p-toast-message {
+  border-radius: .25rem;
+}
+
 .p-inputtext,
 .p-textarea,
 .p-select,

--- a/src/passwordapp.ui/src/main.js
+++ b/src/passwordapp.ui/src/main.js
@@ -20,6 +20,8 @@ import Paginator from 'primevue/paginator'
 import Tag from 'primevue/tag'
 import Message from 'primevue/message'
 import Tooltip from 'primevue/tooltip'
+import Toast from 'primevue/toast'
+import ToastService from 'primevue/toastservice'
 
 import 'bootstrap/dist/css/bootstrap.css'
 
@@ -90,6 +92,7 @@ let requiresAppInsights = process.env.VUE_APP_REQUIRES_APP_INSIGHTS == 'true' ? 
       },
     },
   });
+  app.use(ToastService);
 
   app.component('font-awesome-icon', FontAwesomeIcon);
   app.component('Button', Button);
@@ -104,6 +107,7 @@ let requiresAppInsights = process.env.VUE_APP_REQUIRES_APP_INSIGHTS == 'true' ? 
   app.component('Paginator', Paginator);
   app.component('Tag', Tag);
   app.component('Message', Message);
+  app.component('Toast', Toast);
   app.directive('tooltip', Tooltip);
 
   app.mount('#app');


### PR DESCRIPTION
## Summary
- use themed toasts for copy/create/update/delete success feedback across themes
- tighten classic mobile Account/Site/Last Modified alignment and ellipsis truncation
- make the vault mobile action row span the card and evenly space icon actions

## Validation
- npm run lint -- --quiet
- npm run build -- --mode development