### PR TITLE
Force Settings into classic navigation

### DIFF
--- a/src/passwordapp.ui/src/App.vue
+++ b/src/passwordapp.ui/src/App.vue
@@ -14,10 +14,16 @@
         <font-awesome-icon icon="bars" />
         Menu
       </button>
-      <nav id="vault-navigation" class="vault-nav" :class="{ 'is-open': navOpen }" aria-label="Vault navigation" @click="closeNav">
+      <nav v-if="currentTheme === 'classic'" id="vault-navigation" class="vault-nav vault-nav-classic" aria-label="Vault navigation">
         <template v-if="vaultUnlocked">
-          <router-link class="classic-only" :to="{ name: 'Create' }">New Account</router-link>
-          <router-link class="non-classic-only" :to="{ name: 'Home' }"><i class="pi pi-id-card"></i> Accounts</router-link>
+          <router-link :to="{ name: 'Create' }">New Account</router-link>
+          <router-link :to="{ name: 'Settings' }"><i class="pi pi-cog"></i> Settings</router-link>
+        </template>
+        <button class="vault-nav-button" type="button" @click="logOut">Sign out</button>
+      </nav>
+      <nav v-else id="vault-navigation" class="vault-nav" :class="{ 'is-open': navOpen }" aria-label="Vault navigation" @click="closeNav">
+        <template v-if="vaultUnlocked">
+          <router-link :to="{ name: 'Home' }"><i class="pi pi-id-card"></i> Accounts</router-link>
           <router-link :to="{ name: 'Settings' }"><i class="pi pi-cog"></i> Settings</router-link>
           <router-link class="non-classic-only" :to="{ name: 'Trash' }"><i class="pi pi-trash"></i> Recycle bin</router-link>
           <router-link class="non-classic-only" :to="{ name: 'Audit' }"><i class="pi pi-shield"></i> Audit</router-link>

--- a/src/passwordapp.ui/src/css/main.css
+++ b/src/passwordapp.ui/src/css/main.css
@@ -212,7 +212,7 @@ body.theme-classic .vault-brand {
   white-space: nowrap;
 }
 
-body.theme-classic .vault-nav {
+body.theme-classic .vault-nav-classic {
   justify-content: flex-start;
   gap: 0;
   margin: 1.25rem 0 2rem;
@@ -221,8 +221,8 @@ body.theme-classic .vault-nav {
   overflow-x: visible;
 }
 
-body.theme-classic .vault-nav a,
-body.theme-classic .vault-nav-button {
+body.theme-classic .vault-nav-classic a,
+body.theme-classic .vault-nav-classic .vault-nav-button {
   min-height: auto;
   padding: 0 .45rem;
   border: 0;
@@ -235,22 +235,22 @@ body.theme-classic .vault-nav-button {
   text-transform: none;
 }
 
-body.theme-classic .vault-nav a::before,
-body.theme-classic .vault-nav-button::before {
+body.theme-classic .vault-nav-classic a::before,
+body.theme-classic .vault-nav-classic .vault-nav-button::before {
   content: '|';
   margin-right: .45rem;
   color: #000;
 }
 
-body.theme-classic .vault-nav-button::after {
+body.theme-classic .vault-nav-classic .vault-nav-button::after {
   content: '|';
   margin-left: .45rem;
   color: #000;
 }
 
-body.theme-classic .vault-nav a.router-link-exact-active,
-body.theme-classic .vault-nav a:hover,
-body.theme-classic .vault-nav-button:hover {
+body.theme-classic .vault-nav-classic a.router-link-exact-active,
+body.theme-classic .vault-nav-classic a:hover,
+body.theme-classic .vault-nav-classic .vault-nav-button:hover {
   color: #06f;
   text-decoration: underline;
 }
@@ -260,7 +260,7 @@ body.theme-classic .classic-only {
 }
 
 body.theme-classic .non-classic-only,
-body.theme-classic .vault-nav i {
+body.theme-classic .vault-nav-classic i {
   display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- render a dedicated classic-theme nav containing New Account, Settings, and Sign out
- scope classic nav CSS to that dedicated block so Settings cannot be lost by mixed non-classic nav rules

## Validation
- static assertion: classic nav contains New Account, Settings, Sign out in order
- npm run lint -- --quiet
- npm run build -- --mode development