### PR TITLE
Copy iOS passwords without retry dialog

### DIFF
--- a/src/passwordapp.ui/src/components/home/home.js
+++ b/src/passwordapp.ui/src/components/home/home.js
@@ -2,7 +2,7 @@ import PasswordService from '@/components/api/Password.Service.js';
 import Moment from 'moment';
 import Authentication from '@/components/azuread/AzureAD.Authentication.js';
 import { loadSettings } from '@/components/settings/settings.store.js';
-import { copyWithAutoClear } from '@/components/utils/clipboard.js';
+import { copyDeferredTextWithAutoClear, copyWithAutoClear } from '@/components/utils/clipboard.js';
 import { parseTags, collectTags, hasTag } from '@/components/utils/tags.js';
 import { isStale, ageLabel } from '@/components/utils/age.js';
 import { useAccountsStore } from '@/stores/accounts.store.js';
@@ -70,9 +70,6 @@ export default {
       showDeleteModal:    false,
       showAlertModal:     false,
       showHistoryModal:   false,
-      showClipboardRetryModal: false,
-      clipboardRetryText: '',
-      clipboardRetryError: '',
       apiError:           '',
       accountRefreshTimer: null,
     };
@@ -245,37 +242,15 @@ export default {
         });
     },
     copyPassword(passwordId) {
-      PasswordService.get(passwordId)
-        .then(response => this.writeSecretToClipboard(response.data.currentPassword))
-        .catch(err => {
-          this.requestClipboardRetry('', err);
-        });
-    },
-    requestClipboardRetry(text, error) {
-      this.clipboardRetryText = text || '';
-      this.clipboardRetryError = error ? String(error) : '';
-      this.showClipboardRetryModal = Boolean(text);
-      if (!text) {
-        this.showAlert('Error. . .', "Copy failed with error: " + error);
-      }
-    },
-    retryClipboardCopy() {
-      const text = this.clipboardRetryText;
-      this.clipboardRetryError = '';
-      copyWithAutoClear(text, this.clipboardClearSeconds)
+      const password = PasswordService.get(passwordId)
+        .then(response => response.data.currentPassword);
+      copyDeferredTextWithAutoClear(password, this.clipboardClearSeconds)
         .then(() => {
-          this.showClipboardRetryModal = false;
-          this.clipboardRetryText = '';
           this.showCopyToast();
         })
         .catch(err => {
-          this.clipboardRetryError = String(err);
+          this.showAlert('Error. . .', "Copy failed with error: " + err);
         });
-    },
-    cancelClipboardRetry() {
-      this.showClipboardRetryModal = false;
-      this.clipboardRetryText = '';
-      this.clipboardRetryError = '';
     },
     copySuccessMessage() {
       const secs = Number(this.clipboardClearSeconds);

--- a/src/passwordapp.ui/src/components/home/home.vue
+++ b/src/passwordapp.ui/src/components/home/home.vue
@@ -177,19 +177,6 @@
       </template>
     </Dialog>
 
-    <Dialog v-model:visible="showClipboardRetryModal" modal header="Copy Password" :style="{ width: '30rem' }" @hide="cancelClipboardRetry()">
-      <p class="my-4">
-        This device needs a direct tap before it allows clipboard access. Tap Copy now to finish copying the password.
-      </p>
-      <Message v-if="clipboardRetryError" severity="error" class="mb-3 py-2">
-        Copy failed with error: {{ clipboardRetryError }}
-      </Message>
-      <template #footer>
-        <Button label="Cancel" severity="secondary" @click="cancelClipboardRetry()" />
-        <Button label="Copy now" severity="success" @click.stop="retryClipboardCopy()" />
-      </template>
-    </Dialog>
-
     <Dialog v-model:visible="showHistoryModal" modal header="Password History" :style="{ width: '50rem' }">
       <p v-if="history.length === 0" class="my-4">No password history is available for this account.</p>
       <DataTable v-else :value="history" stripedRows size="small" responsiveLayout="stack">

--- a/src/passwordapp.ui/src/components/utils/clipboard.js
+++ b/src/passwordapp.ui/src/components/utils/clipboard.js
@@ -51,6 +51,22 @@ export function writeClipboardText(text, deps = {}) {
   return legacyCopyText(text, documentRef);
 }
 
+function scheduleAutoClear(clipboard, documentRef, seconds, setTimer, clearTimer) {
+  if (pendingClear !== null) {
+    clearTimer(pendingClear);
+    pendingClear = null;
+  }
+
+  const secs = Number(seconds);
+  if (Number.isFinite(secs) && secs > 0) {
+    pendingClear = setTimer(() => {
+      pendingClear = null;
+      // Best-effort: ignore failures (e.g. document lost focus).
+      writeClipboardText('', { clipboard, documentRef }).catch(() => {});
+    }, secs * 1000);
+  }
+}
+
 export function copyWithAutoClear(text, seconds, deps = {}) {
   const {
     clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined,
@@ -60,22 +76,44 @@ export function copyWithAutoClear(text, seconds, deps = {}) {
   } = deps;
 
   return writeClipboardText(text, { clipboard, documentRef }).then(() => {
-    if (pendingClear !== null) {
-      clearTimer(pendingClear);
-      pendingClear = null;
-    }
-
-    const secs = Number(seconds);
-    if (Number.isFinite(secs) && secs > 0) {
-      pendingClear = setTimer(() => {
-        pendingClear = null;
-        // Best-effort: ignore failures (e.g. document lost focus).
-        writeClipboardText('', { clipboard, documentRef }).catch(() => {});
-      }, secs * 1000);
-    }
-
+    scheduleAutoClear(clipboard, documentRef, seconds, setTimer, clearTimer);
     return true;
   });
+}
+
+export function copyDeferredTextWithAutoClear(textPromise, seconds, deps = {}) {
+  const {
+    clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined,
+    documentRef = typeof document !== 'undefined' ? document : undefined,
+    ClipboardItemCtor = typeof ClipboardItem !== 'undefined' ? ClipboardItem : undefined,
+    BlobCtor = typeof Blob !== 'undefined' ? Blob : undefined,
+    setTimer = (fn, ms) => setTimeout(fn, ms),
+    clearTimer = (id) => clearTimeout(id),
+  } = deps;
+
+  if (
+    clipboard &&
+    typeof clipboard.write === 'function' &&
+    typeof ClipboardItemCtor === 'function' &&
+    typeof BlobCtor === 'function'
+  ) {
+    const item = new ClipboardItemCtor({
+      'text/plain': Promise.resolve(textPromise)
+        .then(text => new BlobCtor([text], { type: 'text/plain' })),
+    });
+    return Promise.resolve(clipboard.write([item])).then(() => {
+      scheduleAutoClear(clipboard, documentRef, seconds, setTimer, clearTimer);
+      return true;
+    });
+  }
+
+  return Promise.resolve(textPromise)
+    .then(text => copyWithAutoClear(text, seconds, {
+      clipboard,
+      documentRef,
+      setTimer,
+      clearTimer,
+    }));
 }
 
 // Exposed for tests to reset module state between cases.

--- a/src/passwordapp.ui/tests/unit/clipboard.spec.js
+++ b/src/passwordapp.ui/tests/unit/clipboard.spec.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { copyWithAutoClear, writeClipboardText, _resetPendingClear } from '@/components/utils/clipboard.js';
+import {
+  copyDeferredTextWithAutoClear,
+  copyWithAutoClear,
+  writeClipboardText,
+  _resetPendingClear,
+} from '@/components/utils/clipboard.js';
 
 function fakeClipboard() {
   return {
@@ -57,6 +62,53 @@ describe('writeClipboardText', () => {
 describe('copyWithAutoClear', () => {
   beforeEach(() => {
     _resetPendingClear();
+  });
+
+  describe('copyDeferredTextWithAutoClear', () => {
+    beforeEach(() => {
+      _resetPendingClear();
+    });
+
+    it('starts clipboard.write synchronously with a deferred ClipboardItem payload', async () => {
+      const writes = [];
+      const clipboard = {
+        write: vi.fn(items => {
+          writes.push(items);
+          return Promise.resolve();
+        }),
+      };
+      const ClipboardItemCtor = vi.fn(function ClipboardItem(items) {
+        this.items = items;
+      });
+      const BlobCtor = vi.fn(function Blob(parts, options) {
+        this.parts = parts;
+        this.options = options;
+      });
+      const textPromise = Promise.resolve('ios-secret');
+
+      const copyPromise = copyDeferredTextWithAutoClear(textPromise, 0, {
+        clipboard,
+        ClipboardItemCtor,
+        BlobCtor,
+      });
+
+      expect(clipboard.write).toHaveBeenCalledTimes(1);
+      expect(ClipboardItemCtor).toHaveBeenCalledTimes(1);
+      await copyPromise;
+      const blob = await writes[0][0].items['text/plain'];
+      expect(blob.parts).toEqual(['ios-secret']);
+      expect(blob.options).toEqual({ type: 'text/plain' });
+    });
+
+    it('falls back to writeText after the text resolves when deferred ClipboardItem is unavailable', async () => {
+      const clipboard = fakeClipboard();
+      await copyDeferredTextWithAutoClear(Promise.resolve('fallback-secret'), 0, {
+        clipboard,
+        ClipboardItemCtor: undefined,
+        BlobCtor: undefined,
+      });
+      expect(clipboard.writes).toEqual(['fallback-secret']);
+    });
   });
 
   it('writes the text to the clipboard', async () => {


### PR DESCRIPTION
## Summary
- remove the Copy Password retry dialog/direct-tap workaround
- use a deferred ClipboardItem payload so clipboard.write is invoked synchronously from the original tap while the password fetch resolves asynchronously
- keep fallback behavior for browsers without ClipboardItem support

## Validation
- npx vitest run tests/unit/clipboard.spec.js
- npm run lint -- --quiet
- npm run build -- --mode development